### PR TITLE
Adds headers.Authorization basic when api.username and api.password is set

### DIFF
--- a/src/Github.php
+++ b/src/Github.php
@@ -62,6 +62,11 @@ class Github
 		{
 			$this->setOption('api.url', 'https://api.github.com');
 		}
+
+		if ($this->getOption('api.password') && $this->getOption('api.username')) 
+		{
+			$this->client->setOption('headers.Authorization','Basic '.base64_encode($this->getOption('api.username').':'.$this->getOption('api.password')));
+		}
 	}
 
 	/**


### PR DESCRIPTION
When accessing private Github repos the user needs to be authenticated.  In addition to OAuth basic authentication can be used.  This requires the correct header set on the Github HTTP client object.  If they are not set Github returns a 404 error.

Just passing the username and password in the URL (the current behaviour) are not sufficient to ensure basic authentication.

This PR checks whether the api.password and api.username are being passed to the Github constructor at initialisation.  If they are this will set the HTTP client Authorization header to Basic and include the base64 encoded api.username and api.password.  

Eric.
