### PR TITLE
Add Emojis API

### DIFF
--- a/Tests/Package/EmojisTest.php
+++ b/Tests/Package/EmojisTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Github\Tests;
+
+use Joomla\Github\Package\Emojis;
+use Joomla\Registry\Registry;
+
+/**
+ * Test class for Emojis.
+ *
+ * @since  1.1.2
+ */
+class EmojisTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var    Registry  Options for the GitHub object.
+	 * @since  1.0
+	 */
+	protected $options;
+
+	/**
+	 * @var    \PHPUnit_Framework_MockObject_MockObject  Mock client object.
+	 * @since  1.0
+	 */
+	protected $client;
+
+	/**
+	 * @var    \Joomla\Http\Response  Mock response object.
+	 * @since  1.0
+	 */
+	protected $response;
+
+	/**
+	 * @var Emojis
+	 */
+	protected $object;
+
+	/**
+	 * @var    string  Sample JSON string.
+	 * @since  11.4
+	 */
+	protected $sampleString = '{"a":1,"b":2,"c":3,"d":4,"e":5}';
+
+	/**
+	 * @var    string  Sample JSON error message.
+	 * @since  11.4
+	 */
+	protected $errorString = '{"message": "Generic Error"}';
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @access protected
+	 *
+	 * @return void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->options  = new Registry;
+		$this->client = $this->getMock('\\Joomla\\Github\\Http', array('get', 'post', 'delete', 'patch', 'put'));
+		$this->response = $this->getMock('JHttpResponse');
+
+		$this->object = new Emojis($this->options, $this->client);
+	}
+
+	/**
+	 * Tests the getList method
+	 *
+	 * @return void
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
+
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/emojis')
+			->will($this->returnValue($this->response));
+
+		$this->assertThat(
+			$this->object->getList('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
+
+	/**
+	 * Tests the getList method - simulated failure
+	 *
+	 * @return void
+	 */
+	public function testGetListFailure()
+	{
+		$exception = false;
+
+		$this->response->code = 500;
+		$this->response->body = $this->errorString;
+
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/emojis')
+			->will($this->returnValue($this->response));
+
+		try
+		{
+			$this->object->getList();
+		}
+		catch (\DomainException $e)
+		{
+			$exception = true;
+
+			$this->assertThat(
+				$e->getMessage(),
+				$this->equalTo(json_decode($this->errorString)->message)
+			);
+		}
+
+		$this->assertTrue($exception);
+	}
+}

--- a/src/Github.php
+++ b/src/Github.php
@@ -16,6 +16,7 @@ use Joomla\Registry\Registry;
  * @property-read  Package\Activity       $activity       GitHub API object for the activity package.
  * @property-read  Package\Authorization  $authorization  GitHub API object for the authorizations package.
  * @property-read  Package\Data           $data           GitHub API object for the data package.
+ * @property-read  Package\Emojis         $emojis         GitHub API object for the emojis package.
  * @property-read  Package\Gists          $gists          GitHub API object for the gists package.
  * @property-read  Package\Gitignore      $gitignore      GitHub API object for the gitignore package.
  * @property-read  Package\Issues         $issues         GitHub API object for the issues package.

--- a/src/Package/Emojis.php
+++ b/src/Package/Emojis.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Part of the Joomla Framework Github Package
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Github\Package;
+
+use Joomla\Github\AbstractPackage;
+
+/**
+ * GitHub API Emojis class for the Joomla Framework.
+ *
+ * @since  1.0
+ *
+ * @documentation  http://developer.github.com/v3/emojis/
+ */
+class Emojis extends AbstractPackage
+{
+	/**
+	 * Lists all the emojis available to use on GitHub.
+	 *
+	 * @return array
+	 *
+	 * @since  1.1
+	 * @throws \DomainException
+	 */
+	public function getList()
+	{
+		// Build the request path.
+		$path = '/emojis';
+
+		// Send the request.
+		$response = $this->client->get($this->fetchUrl($path));
+
+		// Validate the response code.
+		if ($response->code != 200)
+		{
+			// Decode the error response and throw an exception.
+			$error = json_decode($response->body);
+			throw new \DomainException($error->message, $response->code);
+		}
+
+		return json_decode($response->body);
+	}
+}


### PR DESCRIPTION
There is a very important part of the GitHub API missing in Joomla!'s implementation. Not sure how anybody could live without them so here it is: The [GitHub Emoji API](https://developer.github.com/v3/emojis/) 
`<big>`:wink:`</big>`
