### PR TITLE
[RFC] Return Response objects from the API methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "homepage": "https://github.com/joomla-framework/github-api",
     "license": "GPL-2.0+",
     "require": {
-        "php": ">=5.3.10",
+        "php": ">=5.4",
         "joomla/date": "~1.0",
-        "joomla/http": "~1.0",
+        "joomla/http": "2.0.*@dev",
         "joomla/registry": "2.0.*@dev",
         "joomla/uri": "~1.0"
     },

--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Github;
 
+use Joomla\Http\Exception\UnexpectedResponseException;
 use Joomla\Http\Response;
 use Joomla\Uri\Uri;
 use Joomla\Registry\Registry;
@@ -115,7 +116,7 @@ abstract class AbstractGithubObject
 	 * @return  mixed
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	protected function processResponse(Response $response, $expectedCode = 200)
 	{
@@ -124,10 +125,13 @@ abstract class AbstractGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
+
+			// Check if the error message is set; send a generic one if not
 			$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
-			throw new \DomainException($message, $response->code);
+
+			throw new UnexpectedResponseException($response, $message, $response->code);
 		}
 
-		return json_decode($response->body);
+		return $response;
 	}
 }

--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -121,7 +121,7 @@ abstract class AbstractGithubObject
 	protected function processResponse(Response $response, $expectedCode = 200)
 	{
 		// Validate the response code.
-		if ($response->code != $expectedCode)
+		if ($response->getStatusCode() != $expectedCode)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);


### PR DESCRIPTION
This fails CI right now because I haven't touched the tests at all, but this serves as an RFC/demo of sorts for how I want to see our social packages structured in 2.0.

In the 1.0 code, our response handlers check for an expected response code and if it doesn't exist, we throw an Exception with an error message and the response code, and on a successful response we return the Response object's decoded body.  This limits the usefulness of the API data as we strip away the full response data in both success and error conditions.

This restructures the package to always return a Response object.  The success scenario will simply return the Response object unaltered, the fail scenario will still check the response body and throw an Exception, but will now throw the `UnexpectedResponseException` added to the HTTP package which requires the Response object to be attached to it.

I've elected to bump to the HTTP 2.0 package here in order to use our PSR-7 based Response object, which forces a PHP 5.4 bump based on the underlying dependencies.

Thoughts?