### PR TITLE
Update doc blocks

### DIFF
--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -101,7 +101,7 @@ abstract class AbstractGithubObject
 	 */
 	protected function fetchUrl($path, $page = 0, $limit = 0)
 	{
-		// Get a new Uri object fousing the api url and given path.
+		// Get a new Uri object focusing the api url and given path.
 		$uri = new Uri($this->options->get('api.url') . $path);
 
 		if ($this->options->get('gh.token', false))

--- a/src/Package/Activity/Events.php
+++ b/src/Package/Activity/Events.php
@@ -97,9 +97,9 @@ class Events extends AbstractPackage
 	}
 
 	/**
-	 * List public events for an organisation.
+	 * List public events for an organization.
 	 *
-	 * @param   string  $org  Organisation.
+	 * @param   string  $org  Organization.
 	 *
 	 * @return  object
 	 *

--- a/src/Package/Activity/Feeds.php
+++ b/src/Package/Activity/Feeds.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Feeds extends AbstractPackage
 {
 	/**
-	 * List feeds.
+	 * List Feeds.
 	 *
 	 * @return  object
 	 *

--- a/src/Package/Activity/Starring.php
+++ b/src/Package/Activity/Starring.php
@@ -70,7 +70,7 @@ class Starring extends AbstractPackage
 	 * @param   string  $owner  Repository owner.
 	 * @param   string  $repo   Repository name.
 	 *
-	 * @return  object
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException

--- a/src/Package/Activity/Watching.php
+++ b/src/Package/Activity/Watching.php
@@ -138,7 +138,7 @@ class Watching extends AbstractPackage
 	 * @param   string  $owner  Repository owner.
 	 * @param   string  $repo   Repository name.
 	 *
-	 * @return  object
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException

--- a/src/Package/Authorization.php
+++ b/src/Package/Authorization.php
@@ -338,7 +338,7 @@ class Authorization extends AbstractPackage
 		// Send the request.
 		return $this->processResponse(
 			$this->client->post($uri, $data, $headers),
-			200, false
+			200
 		);
 	}
 }

--- a/src/Package/Data/Commits.php
+++ b/src/Package/Data/Commits.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Commits extends AbstractPackage
 {
 	/**
-	 * Get a single commit.
+	 * Get a Commit.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -39,7 +39,7 @@ class Commits extends AbstractPackage
 	}
 
 	/**
-	 * Method to create a commit.
+	 * Create a Commit.
 	 *
 	 * @param   string  $owner    The name of the owner of the GitHub repository.
 	 * @param   string  $repo     The name of the GitHub repository.

--- a/src/Package/Data/Refs.php
+++ b/src/Package/Data/Refs.php
@@ -21,7 +21,7 @@ use Joomla\Github\AbstractPackage;
 class Refs extends AbstractPackage
 {
 	/**
-	 * Method to get a reference.
+	 * Get a Reference.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -52,7 +52,7 @@ class Refs extends AbstractPackage
 	}
 
 	/**
-	 * Method to list references for a repository.
+	 * Get all References.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -85,7 +85,7 @@ class Refs extends AbstractPackage
 	}
 
 	/**
-	 * Method to create a ref.
+	 * Create a Reference.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -125,7 +125,7 @@ class Refs extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a reference.
+	 * Update a Reference.
 	 *
 	 * @param   string   $user   The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -143,7 +143,7 @@ class Refs extends AbstractPackage
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/git/refs/' . $ref;
 
-		// Craete the data object.
+		// Create the data object.
 		$data = new \stdClass;
 
 		// If a title is set add it to the data object.

--- a/src/Package/Gists.php
+++ b/src/Package/Gists.php
@@ -22,7 +22,7 @@ use Joomla\Github\AbstractPackage;
 class Gists extends AbstractPackage
 {
 	/**
-	 * Method to create a gist.
+	 * Create a gist.
 	 *
 	 * @param   mixed    $files        Either an array of file paths or a single file path as a string.
 	 * @param   boolean  $public       True if the gist should be public.
@@ -62,7 +62,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a gist.
+	 * Delete a gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 *
@@ -89,7 +89,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a gist.
+	 * Edit a gist.
 	 *
 	 * @param   integer  $gistId       The gist number.
 	 * @param   mixed    $files        Either an array of file paths or a single file path as a string.
@@ -106,7 +106,7 @@ class Gists extends AbstractPackage
 		// Build the request path.
 		$path = '/gists/' . (int) $gistId;
 
-		// Craete the data object.
+		// Create the data object.
 		$data = new \stdClass;
 
 		// If a description is set add it to the data object.
@@ -145,7 +145,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to fork a gist.
+	 * Fork a gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 *
@@ -164,7 +164,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single gist.
+	 * Get a single gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 *
@@ -193,7 +193,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to list commits of a gist.
+	 * List gist commits.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 * @param   integer  $page    The page number from which to get items.
@@ -214,7 +214,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to list forks of a gist.
+	 * List gist forks.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 * @param   integer  $page    The page number from which to get items.
@@ -245,7 +245,9 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to list gists.  If a user is authenticated it will return the user's gists, otherwise
+	 * List gists.
+	 *
+	 * If a user is authenticated it will return the user's gists, otherwise
 	 * it will return all public gists.
 	 *
 	 * @param   integer  $page   The page number from which to get items.
@@ -276,7 +278,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a list of gists belonging to a given user.
+	 * List a user’s gists.
 	 *
 	 * @param   string   $user   The name of the GitHub user from which to list gists.
 	 * @param   integer  $page   The page number from which to get items.
@@ -307,7 +309,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a list of all public gists.
+	 * List all public gists.
 	 *
 	 * @param   integer  $page   The page number from which to get items.
 	 * @param   integer  $limit  The number of items on a page.
@@ -337,7 +339,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a list of the authenticated users' starred gists.
+	 * List starred gists.
 	 *
 	 * @param   integer  $page   The page number from which to get items.
 	 * @param   integer  $limit  The number of items on a page.
@@ -367,7 +369,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a revision of a gist.
+	 * Get a specific revision of a gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 * @param   string   $sha     The SHA for the revision to get.
@@ -387,7 +389,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to check if a gist has been starred.
+	 * Check if a gist is starred.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 *
@@ -422,7 +424,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to star a gist.
+	 * Star a gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 *
@@ -449,7 +451,7 @@ class Gists extends AbstractPackage
 	}
 
 	/**
-	 * Method to star a gist.
+	 * Unstar a gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 *

--- a/src/Package/Gists/Comments.php
+++ b/src/Package/Gists/Comments.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Comments extends AbstractPackage
 {
 	/**
-	 * Method to create a comment on a gist.
+	 * Create a comment.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 * @param   string   $body    The comment body text.
@@ -57,7 +57,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a comment on a gist.
+	 * Delete a comment.
 	 *
 	 * @param   integer  $commentId  The id of the comment to delete.
 	 *
@@ -84,7 +84,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a comment on a gist.
+	 * Edit a comment.
 	 *
 	 * @param   integer  $commentId  The id of the comment to update.
 	 * @param   string   $body       The new body text for the comment.
@@ -121,7 +121,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a specific comment on a gist.
+	 * Get a single comment.
 	 *
 	 * @param   integer  $commentId  The comment id to get.
 	 *
@@ -150,7 +150,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the list of comments on a gist.
+	 * List comments on a gist.
 	 *
 	 * @param   integer  $gistId  The gist number.
 	 * @param   integer  $page    The page number from which to get items.

--- a/src/Package/Issues.php
+++ b/src/Package/Issues.php
@@ -28,7 +28,7 @@ use Joomla\Uri\Uri;
 class Issues extends AbstractPackage
 {
 	/**
-	 * Method to create an issue.
+	 * Create an issue.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -80,7 +80,7 @@ class Issues extends AbstractPackage
 	}
 
 	/**
-	 * Method to update an issue.
+	 * Edit an issue.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -102,7 +102,7 @@ class Issues extends AbstractPackage
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/issues/' . (int) $issueId;
 
-		// Craete the data object.
+		// Create the data object.
 		$data = new \stdClass;
 
 		// If a title is set add it to the data object.
@@ -165,7 +165,7 @@ class Issues extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single issue.
+	 * Get a single issue.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.
@@ -196,7 +196,7 @@ class Issues extends AbstractPackage
 	}
 
 	/**
-	 * Method to list an authenticated user's issues.
+	 * List issues.
 	 *
 	 * @param   string   $filter     The filter type: assigned, created, mentioned, subscribed.
 	 * @param   string   $state      The optional state to filter requests by. [open, closed]
@@ -265,7 +265,7 @@ class Issues extends AbstractPackage
 	}
 
 	/**
-	 * Method to list issues.
+	 * List issues for a repository.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -348,7 +348,7 @@ class Issues extends AbstractPackage
 	}
 
 	/**
-	 * Method to lock an issue.
+	 * Lock an issue.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.
@@ -368,7 +368,7 @@ class Issues extends AbstractPackage
 	}
 
 	/**
-	 * Method to unlock an issue.
+	 * Unlock an issue.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.

--- a/src/Package/Issues/Comments.php
+++ b/src/Package/Issues/Comments.php
@@ -24,7 +24,7 @@ use Joomla\Date\Date;
 class Comments extends AbstractPackage
 {
 	/**
-	 * Method to get the list of comments on an issue.
+	 * List comments on an issue.
 	 *
 	 * @param   string   $owner    The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.
@@ -49,7 +49,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the list of comments in a repository.
+	 * List comments in a repository.
 	 *
 	 * @param   string  $owner      The name of the owner of the GitHub repository.
 	 * @param   string  $repo       The name of the GitHub repository.
@@ -99,7 +99,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single comment.
+	 * Get a single comment.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -119,7 +119,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a comment on an issue.
+	 * Edit a comment.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -150,7 +150,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to create a comment on an issue.
+	 * Create a comment.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.
@@ -182,7 +182,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a comment on an issue.
+	 * Delete a comment.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.

--- a/src/Package/Issues/Labels.php
+++ b/src/Package/Issues/Labels.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Labels extends AbstractPackage
 {
 	/**
-	 * Method to get the list of labels on a repo.
+	 * List all labels for this repository.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -41,7 +41,7 @@ class Labels extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a specific label on a repo.
+	 * Get a single label.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -63,7 +63,7 @@ class Labels extends AbstractPackage
 	}
 
 	/**
-	 * Method to create a label on a repo.
+	 * Create a label.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -103,7 +103,7 @@ class Labels extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a label on a repo.
+	 * Delete a label.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -126,7 +126,7 @@ class Labels extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a label on a repo.
+	 * Update a label.
 	 *
 	 * @param   string  $user   The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.

--- a/src/Package/Issues/Milestones.php
+++ b/src/Package/Issues/Milestones.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Milestones extends AbstractPackage
 {
 	/**
-	 * Method to get the list of milestones for a repo.
+	 * List milestones for a repository.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -59,7 +59,7 @@ class Milestones extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a specific milestone.
+	 * Get a single milestone.
 	 *
 	 * @param   string   $user         The name of the owner of the GitHub repository.
 	 * @param   string   $repo         The name of the GitHub repository.
@@ -90,7 +90,7 @@ class Milestones extends AbstractPackage
 	}
 
 	/**
-	 * Method to create a milestone for a repository.
+	 * Create a milestone.
 	 *
 	 * @param   string   $user         The name of the owner of the GitHub repository.
 	 * @param   string   $repo         The name of the GitHub repository.
@@ -146,7 +146,7 @@ class Milestones extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a milestone.
+	 * Update a milestone.
 	 *
 	 * @param   string   $user         The name of the owner of the GitHub repository.
 	 * @param   string   $repo         The name of the GitHub repository.
@@ -206,7 +206,7 @@ class Milestones extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a milestone.
+	 * Delete a milestone.
 	 *
 	 * @param   string   $user         The name of the owner of the GitHub repository.
 	 * @param   string   $repo         The name of the GitHub repository.

--- a/src/Package/Orgs.php
+++ b/src/Package/Orgs.php
@@ -24,7 +24,7 @@ use Joomla\Github\AbstractPackage;
 class Orgs extends AbstractPackage
 {
 	/**
-	 * List User Organizations.
+	 * List user organizations.
 	 *
 	 * If a user name is given, public and private organizations for the authenticated user will be listed.
 	 *
@@ -48,7 +48,7 @@ class Orgs extends AbstractPackage
 	}
 
 	/**
-	 * Get an Organization.
+	 * Get an organization.
 	 *
 	 * @param   string  $org  The organization name.
 	 *
@@ -68,7 +68,7 @@ class Orgs extends AbstractPackage
 	}
 
 	/**
-	 * Edit an Organization.
+	 * Edit an organization.
 	 *
 	 * @param   string  $org           The organization name.
 	 * @param   string  $billingEmail  Billing email address. This address is not publicized.

--- a/src/Package/Orgs/Hooks.php
+++ b/src/Package/Orgs/Hooks.php
@@ -42,7 +42,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Get hook.
+	 * Get single hook.
 	 *
 	 * @param   string   $org  The name of the organization.
 	 * @param   integer  $id   The hook id.
@@ -62,7 +62,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Create hook.
+	 * Create a hook.
 	 *
 	 * @param   string   $org          The name of the organization.
 	 * @param   string   $url          The URL to which the payloads will be delivered.
@@ -205,7 +205,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Trigger a ping event for a hook
+	 * Ping a hook.
 	 *
 	 * @param   string   $org  The name of the organization
 	 * @param   integer  $id   ID of the hook to ping
@@ -227,7 +227,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Delete hook.
+	 * Delete a hook.
 	 *
 	 * @param   string   $org  The name of the organization
 	 * @param   integer  $id   ID of the hook to delete

--- a/src/Package/Orgs/Members.php
+++ b/src/Package/Orgs/Members.php
@@ -164,7 +164,7 @@ class Members extends AbstractPackage
 	 * @throws \UnexpectedValueException
 	 * @since  1.0
 	 *
-	 * @return object
+	 * @return boolean
 	 */
 	public function checkPublic($org, $user)
 	{
@@ -341,7 +341,7 @@ class Members extends AbstractPackage
 	}
 
 	/**
-	 * Get your organization membership
+	 * Edit your organization membership
 	 *
 	 * @param   string  $org    The name of the organization.
 	 * @param   string  $state  The state that the membership should be in.

--- a/src/Package/Orgs/Teams.php
+++ b/src/Package/Orgs/Teams.php
@@ -200,7 +200,7 @@ class Teams extends AbstractPackage
 	 * @param   integer  $id    The team id.
 	 * @param   string   $user  The name of the user.
 	 *
-	 * @return  object
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
@@ -395,13 +395,13 @@ class Teams extends AbstractPackage
 	}
 
 	/**
-	 * Check if the repo is managed by this team.
+	 * Check if a team manages a repository.
 	 *
 	 * @param   integer  $id     The team id.
 	 * @param   string   $owner  The owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
 	 *
-	 * @return  object
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 * @throws  \UnexpectedValueException
@@ -432,7 +432,7 @@ class Teams extends AbstractPackage
 	}
 
 	/**
-	 * Add team repo.
+	 * Add or update team repository.
 	 *
 	 * In order to add a repo to a team, the authenticated user must be an owner of the
 	 * org that the team is associated with. Also, the repo must be owned by the organization,
@@ -461,7 +461,7 @@ class Teams extends AbstractPackage
 	}
 
 	/**
-	 * Remove team repo.
+	 * Remove team repository.
 	 *
 	 * In order to remove a repo from a team, the authenticated user must be an owner
 	 * of the org that the team is associated with. NOTE: This does not delete the

--- a/src/Package/Pulls.php
+++ b/src/Package/Pulls.php
@@ -22,7 +22,7 @@ use Joomla\Github\AbstractPackage;
 class Pulls extends AbstractPackage
 {
 	/**
-	 * Method to create a pull request.
+	 * Create a pull request.
 	 *
 	 * @param   string  $user   The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -114,7 +114,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a pull request.
+	 * Update a pull request.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -133,7 +133,7 @@ class Pulls extends AbstractPackage
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/pulls/' . (int) $pullId;
 
-		// Craete the data object.
+		// Create the data object.
 		$data = new \stdClass;
 
 		// If a title is set add it to the data object.
@@ -172,7 +172,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single pull request.
+	 * Get a single pull request.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -203,7 +203,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a list of commits for a pull request.
+	 * List commits on a pull request.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -236,7 +236,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a list of files for a pull request.
+	 * List pull requests files.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -269,7 +269,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to list pull requests.
+	 * List pull requests.
 	 *
 	 * @param   string   $user   The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -308,7 +308,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to check if a pull request has been merged.
+	 * Get if a pull request has been merged.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -345,7 +345,7 @@ class Pulls extends AbstractPackage
 	}
 
 	/**
-	 * Method to merge a pull request.
+	 * Merge a pull request (Merge Button).
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.

--- a/src/Package/Pulls/Comments.php
+++ b/src/Package/Pulls/Comments.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Comments extends AbstractPackage
 {
 	/**
-	 * Method to create a comment on a pull request.
+	 * Create a comment.
 	 *
 	 * @param   string   $user      The name of the owner of the GitHub repository.
 	 * @param   string   $repo      The name of the GitHub repository.
@@ -90,7 +90,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a comment on a pull request.
+	 * Delete a comment.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -113,7 +113,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a comment on a pull request.
+	 * Edit a comment.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -143,7 +143,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a specific comment on a pull request.
+	 * Get a single comment.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -165,7 +165,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the list of comments on a pull request.
+	 * List comments on a pull request.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -189,7 +189,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the list of comments on a repository's pull requests.
+	 * List comments in a repository.
 	 *
 	 * @param   string   $user   The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.

--- a/src/Package/Repositories.php
+++ b/src/Package/Repositories.php
@@ -159,7 +159,7 @@ class Repositories extends AbstractPackage
 	}
 
 	/**
-	 * List all repositories.
+	 * List all public repositories.
 	 *
 	 * This provides a dump of every repository, in the order that they were created.
 	 *
@@ -237,7 +237,7 @@ class Repositories extends AbstractPackage
 	}
 
 	/**
-	 * Get a repository.
+	 * Get.
 	 *
 	 * @param   string  $owner  Repository owner.
 	 * @param   string  $repo   Repository name.
@@ -258,7 +258,7 @@ class Repositories extends AbstractPackage
 	}
 
 	/**
-	 * Edit a repository.
+	 * Edit.
 	 *
 	 * @param   string   $owner           Repository owner.
 	 * @param   string   $repo            Repository name.

--- a/src/Package/Repositories/Branches.php
+++ b/src/Package/Repositories/Branches.php
@@ -41,7 +41,7 @@ class Branches extends AbstractPackage
 	}
 
 	/**
-	 * Get a Branch.
+	 * Get Branch.
 	 *
 	 * @param   string  $owner   Repository owner.
 	 * @param   string  $repo    Repository name.

--- a/src/Package/Repositories/Collaborators.php
+++ b/src/Package/Repositories/Collaborators.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Collaborators extends AbstractPackage
 {
 	/**
-	 * List.
+	 * List collaborators.
 	 *
 	 * When authenticating as an organization owner of an organization-owned repository, all organization
 	 * owners are included in the list of collaborators. Otherwise, only users with access to the repository
@@ -44,7 +44,7 @@ class Collaborators extends AbstractPackage
 	}
 
 	/**
-	 * Test if a user is a collaborator.
+	 * Check if a user is a collaborator.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -79,7 +79,7 @@ class Collaborators extends AbstractPackage
 	}
 
 	/**
-	 * Add collaborator.
+	 * Add user as a collaborator.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -101,7 +101,7 @@ class Collaborators extends AbstractPackage
 	}
 
 	/**
-	 * Remove collaborator.
+	 * Remove user as a collaborator.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.

--- a/src/Package/Repositories/Comments.php
+++ b/src/Package/Repositories/Comments.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Comments extends AbstractPackage
 {
 	/**
-	 * Method to get a list of commit comments for a repository.
+	 * List commit comments for a repository.
 	 *
 	 * @param   string   $user   The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -43,7 +43,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a list of comments for a single commit for a repository.
+	 * List comments for a single commit.
 	 *
 	 * @param   string   $user   The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -67,7 +67,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single comment on a commit.
+	 * Get a single commit comment.
 	 *
 	 * @param   string   $user  The name of the owner of the GitHub repository.
 	 * @param   string   $repo  The name of the GitHub repository.
@@ -89,7 +89,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to edit a comment on a commit.
+	 * Update a commit comment.
 	 *
 	 * @param   string  $user     The name of the owner of the GitHub repository.
 	 * @param   string  $repo     The name of the GitHub repository.
@@ -118,7 +118,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a comment on a commit.
+	 * Delete a commit comment.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -141,7 +141,7 @@ class Comments extends AbstractPackage
 	}
 
 	/**
-	 * Method to create a comment on a commit.
+	 * Create a commit comment.
 	 *
 	 * @param   string   $user      The name of the owner of the GitHub repository.
 	 * @param   string   $repo      The name of the GitHub repository.

--- a/src/Package/Repositories/Commits.php
+++ b/src/Package/Repositories/Commits.php
@@ -21,7 +21,7 @@ use Joomla\Date\Date;
 class Commits extends AbstractPackage
 {
 	/**
-	 * Method to list commits for a repository.
+	 * List commits on a repository.
 	 *
 	 * A special note on pagination: Due to the way Git works, commits are paginated based on SHA
 	 * instead of page number.
@@ -67,7 +67,7 @@ class Commits extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single commit for a repository.
+	 * Get a single commit.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -98,7 +98,7 @@ class Commits extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the SHA-1 of a commit reference
+	 * Get the SHA-1 of a commit reference.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -129,7 +129,7 @@ class Commits extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a diff for two commits.
+	 * Compare two commits.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.

--- a/src/Package/Repositories/Deployments.php
+++ b/src/Package/Repositories/Deployments.php
@@ -21,7 +21,7 @@ use Joomla\Uri\Uri;
 class Deployments extends AbstractPackage
 {
 	/**
-	 * List deployments in a repository.
+	 * List Deployments.
 	 *
 	 * @param   string   $owner        The name of the owner of the GitHub repository.
 	 * @param   string   $repo         The name of the GitHub repository.
@@ -69,7 +69,7 @@ class Deployments extends AbstractPackage
 	}
 
 	/**
-	 * Create a deployment.
+	 * Create a Deployment.
 	 *
 	 * @param   string      $owner             The name of the owner of the GitHub repository.
 	 * @param   string      $repo              The name of the GitHub repository.
@@ -145,7 +145,7 @@ class Deployments extends AbstractPackage
 	}
 
 	/**
-	 * List statuses for a deployment.
+	 * List Deployment Statuses.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -168,7 +168,7 @@ class Deployments extends AbstractPackage
 	}
 
 	/**
-	 * Create a status for a deployment.
+	 * Create a Deployment Status.
 	 *
 	 * @param   string   $owner        The name of the owner of the GitHub repository.
 	 * @param   string   $repo         The name of the GitHub repository.

--- a/src/Package/Repositories/Forks.php
+++ b/src/Package/Repositories/Forks.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Forks extends AbstractPackage
 {
 	/**
-	 * Method to fork a repository.
+	 * Create a fork.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -52,7 +52,7 @@ class Forks extends AbstractPackage
 	}
 
 	/**
-	 * Method to list forks for a repository.
+	 * List forks.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.

--- a/src/Package/Repositories/Hooks.php
+++ b/src/Package/Repositories/Hooks.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Hooks extends AbstractPackage
 {
 	/**
-	 * Method to create a hook on a repository.
+	 * Create a hook.
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
@@ -60,7 +60,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete a hook
+	 * Delete a hook
 	 *
 	 * @param   string   $user  The name of the owner of the GitHub repository.
 	 * @param   string   $repo  The name of the GitHub repository.
@@ -83,7 +83,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Method to edit a hook.
+	 * Edit a hook.
 	 *
 	 * @param   string   $user          The name of the owner of the GitHub repository.
 	 * @param   string   $repo          The name of the GitHub repository.
@@ -148,7 +148,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Method to get details about a single hook for the repository.
+	 * Get single hook.
 	 *
 	 * @param   string   $user  The name of the owner of the GitHub repository.
 	 * @param   string   $repo  The name of the GitHub repository.
@@ -170,7 +170,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Method to list hooks for a repository.
+	 * List hooks.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -191,7 +191,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Method to trigger a ping event for a hook
+	 * Ping a hook.
 	 *
 	 * @param   string   $user  The name of the owner of the GitHub repository.
 	 * @param   string   $repo  The name of the GitHub repository.
@@ -214,7 +214,7 @@ class Hooks extends AbstractPackage
 	}
 
 	/**
-	 * Method to test a hook against the latest repository commit
+	 * Test a `push` hook.
 	 *
 	 * @param   string   $user  The name of the owner of the GitHub repository.
 	 * @param   string   $repo  The name of the GitHub repository.

--- a/src/Package/Repositories/Keys.php
+++ b/src/Package/Repositories/Keys.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Keys extends AbstractPackage
 {
 	/**
-	 * List keys in a repository.
+	 * List deploy keys.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -40,7 +40,7 @@ class Keys extends AbstractPackage
 	}
 
 	/**
-	 * Get a key.
+	 * Get a deploy key.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -61,7 +61,7 @@ class Keys extends AbstractPackage
 	}
 
 	/**
-	 * Create a key.
+	 * Add a new deploy key.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
@@ -89,7 +89,7 @@ class Keys extends AbstractPackage
 	}
 
 	/**
-	 * Edit a key.
+	 * Edit a deploy key.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -117,7 +117,7 @@ class Keys extends AbstractPackage
 	}
 
 	/**
-	 * Delete a key.
+	 * Remove a deploy key.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.

--- a/src/Package/Repositories/Pages.php
+++ b/src/Package/Repositories/Pages.php
@@ -40,7 +40,7 @@ class Pages extends AbstractPackage
 	}
 
 	/**
-	 * List Pages builds in a repository.
+	 * List Pages builds.
 	 *
 	 * @param   string   $owner  The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -62,7 +62,7 @@ class Pages extends AbstractPackage
 	}
 
 	/**
-	 * Get the latest Pages build.
+	 * List latest Pages build.
 	 *
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.

--- a/src/Package/Repositories/Releases.php
+++ b/src/Package/Repositories/Releases.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Releases extends AbstractPackage
 {
 	/**
-	 * Method to create a release.
+	 * Create a release.
 	 *
 	 * @param   string   $user             The name of the owner of the GitHub repository.
 	 * @param   string   $repo             The name of the GitHub repository.
@@ -80,7 +80,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to update a release.
+	 * Edit a release.
 	 *
 	 * @param   string   $user             The name of the owner of the GitHub repository.
 	 * @param   string   $repo             The name of the GitHub repository.
@@ -145,7 +145,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a single release.
+	 * Get a single release.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -166,7 +166,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the latest release.
+	 * Get the latest release.
 	 *
 	 * View the latest published full release for the repository.
 	 * Draft releases and prereleases are not returned by this endpoint.
@@ -188,7 +188,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to get a release by tag name.
+	 * Get a release by tag name.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -208,7 +208,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to list all releases.
+	 * List releases for a repository.
 	 *
 	 * @param   string   $user   The name of the owner of the GitHub repository.
 	 * @param   string   $repo   The name of the GitHub repository.
@@ -242,7 +242,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to list all assets for a release.
+	 * List assets for a release.
 	 *
 	 * @param   string   $user       The name of the owner of the GitHub repository.
 	 * @param   string   $repo       The name of the GitHub repository.
@@ -264,7 +264,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to get an asset for a release.
+	 * Get a single release asset.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.
@@ -284,7 +284,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to edit an asset for a release.
+	 * Edit a release asset.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.
@@ -315,7 +315,7 @@ class Releases extends AbstractPackage
 	}
 
 	/**
-	 * Method to delete an asset for a release.
+	 * Delete a release asset.
 	 *
 	 * @param   string   $user     The name of the owner of the GitHub repository.
 	 * @param   string   $repo     The name of the GitHub repository.

--- a/src/Package/Repositories/Statistics.php
+++ b/src/Package/Repositories/Statistics.php
@@ -96,7 +96,7 @@ class Statistics  extends AbstractPackage
 	}
 
 	/**
-	 * Get the weekly commit count for the repo owner and everyone else.
+	 * Get the weekly commit count for the repository owner and everyone else.
 	 *
 	 * Returns the total commit counts for the "owner" and total commit counts in "all". "all" is everyone combined,
 	 * including the owner in the last 52 weeks.

--- a/src/Package/Repositories/Statuses.php
+++ b/src/Package/Repositories/Statuses.php
@@ -20,7 +20,7 @@ use Joomla\Github\AbstractPackage;
 class Statuses extends AbstractPackage
 {
 	/**
-	 * Method to create a status.
+	 * Create a Status.
 	 *
 	 * @param   string  $user         The name of the owner of the GitHub repository.
 	 * @param   string  $repo         The name of the GitHub repository.
@@ -77,7 +77,7 @@ class Statuses extends AbstractPackage
 	}
 
 	/**
-	 * Method to list statuses for an SHA.
+	 * List Statuses for a specific Ref.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -97,7 +97,7 @@ class Statuses extends AbstractPackage
 	}
 
 	/**
-	 * Method to get the combined Status for a specific Ref.
+	 * Get the combined Status for a specific Ref.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.

--- a/src/Package/Users.php
+++ b/src/Package/Users.php
@@ -45,7 +45,7 @@ class Users extends AbstractPackage
 	}
 
 	/**
-	 * Get the current authenticated user.
+	 * Get the authenticated user.
 	 *
 	 * @return  mixed
 	 *
@@ -64,14 +64,14 @@ class Users extends AbstractPackage
 	}
 
 	/**
-	 * Update a user.
+	 * Update the authenticated user.
 	 *
 	 * @param   string  $name      The full name
 	 * @param   string  $email     The email
 	 * @param   string  $blog      The blog
 	 * @param   string  $company   The company
 	 * @param   string  $location  The location
-	 * @param   string  $hireable  If he is unemplayed :P
+	 * @param   string  $hireable  If he is unemployed :P
 	 * @param   string  $bio       The biometrical DNA fingerprint (or smthng...)
 	 *
 	 * @return  mixed

--- a/src/Package/Users/Followers.php
+++ b/src/Package/Users/Followers.php
@@ -97,7 +97,7 @@ class Followers extends AbstractPackage
 	}
 
 	/**
-	 * Check if a user is following a specified user.
+	 * Check if one user follows another.
 	 *
 	 * @param   string  $user    The name of the user.
 	 * @param   string  $target  The name of the user to check is being followed.
@@ -110,7 +110,6 @@ class Followers extends AbstractPackage
 	public function checkUserFollowing($user, $target)
 	{
 		// Build the request path.
-		// /users/:username/following/:target_user
 		$path = "/user/$user/following/$target";
 
 		$response = $this->client->get($this->fetchUrl($path));


### PR DESCRIPTION
This will update method doc blocks for the following purpose:

I wrote a simple script that compares the GitHub API documentation to our implementation and checks for missing or removed methods.
For this to work, the method doc block "title" has to match the contents of the `<h2>` tag in the documentation. This is already the case in *most* methods, except those treated in this PR.

After the modification the scripts output is like [this](https://gist.github.com/elkuku/f484d6b59edcc09b721cb3372c6ddf19). There are some false positives where GitHub does not follow our expectations, but it seems to work for most of the classes and methods.
The script is [here](https://github.com/elkuku/github-api-sync) for reference.

Actually my intention was to target the master branch to not pollute this PR further... On the other hand it's also some kind of `API-sync` and **just doc blocks**, so here it is :tongue: 