### PR TITLE
Use HTTP package exception on errors

### DIFF
--- a/Tests/Package/EmojisTest.php
+++ b/Tests/Package/EmojisTest.php
@@ -65,7 +65,7 @@ class EmojisTest extends \PHPUnit_Framework_TestCase
 
 		$this->options  = new Registry;
 		$this->client = $this->getMock('\\Joomla\\Github\\Http', array('get', 'post', 'delete', 'patch', 'put'));
-		$this->response = $this->getMock('JHttpResponse');
+		$this->response = $this->getMock('\\Joomla\\Http\\Response');
 
 		$this->object = new Emojis($this->options, $this->client);
 	}

--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Github;
 
+use Joomla\Http\Exception\UnexpectedResponseException;
 use Joomla\Http\Response;
 use Joomla\Uri\Uri;
 use Joomla\Registry\Registry;
@@ -147,7 +148,7 @@ abstract class AbstractGithubObject
 	 * @return  mixed
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	protected function processResponse(Response $response, $expectedCode = 200)
 	{
@@ -157,7 +158,7 @@ abstract class AbstractGithubObject
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
 			$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
-			throw new \DomainException($message, $response->code);
+			throw new UnexpectedResponseException($response, $message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/src/Package/Authorization.php
+++ b/src/Package/Authorization.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github\Package;
 
 use Joomla\Github\AbstractPackage;
+use Joomla\Http\Exception\UnexpectedResponseException;
 use Joomla\Uri\Uri;
 
 /**
@@ -42,17 +43,7 @@ class Authorization extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -71,17 +62,7 @@ class Authorization extends AbstractPackage
 		$path = '/authorizations/' . $id;
 
 		// Send the request.
-		$response = $this->client->delete($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 204)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->delete($this->fetchUrl($path)), 204);
 	}
 
 	/**
@@ -146,17 +127,7 @@ class Authorization extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -176,17 +147,7 @@ class Authorization extends AbstractPackage
 		$path = '/authorizations/' . $id;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -204,17 +165,7 @@ class Authorization extends AbstractPackage
 		$path = '/authorizations';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -224,7 +175,7 @@ class Authorization extends AbstractPackage
 	 *                  `limit` property will be false.
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	public function getRateLimit()
 	{
@@ -245,7 +196,7 @@ class Authorization extends AbstractPackage
 
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
+			throw new UnexpectedResponseException($response, $error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/src/Package/Data/Refs.php
+++ b/src/Package/Data/Refs.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Github\Package\Data;
 
-use DomainException;
 use Joomla\Github\AbstractPackage;
 
 /**
@@ -27,10 +26,10 @@ class Refs extends AbstractPackage
 	 * @param   string  $repo  The name of the GitHub repository.
 	 * @param   string  $ref   The reference to get.
 	 *
-	 * @throws \DomainException
 	 * @return  object
 	 *
-	 * @since  1.0
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function get($user, $repo, $ref)
 	{
@@ -38,17 +37,7 @@ class Refs extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/git/refs/' . $ref;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -60,10 +49,10 @@ class Refs extends AbstractPackage
 	 * @param   integer  $page       Page to request
 	 * @param   integer  $limit      Number of results to return per page
 	 *
-	 * @throws \DomainException
-	 * @return  array
+	 * @return  object
 	 *
-	 * @since  1.0
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function getList($user, $repo, $namespace = '', $page = 0, $limit = 0)
 	{
@@ -71,17 +60,7 @@ class Refs extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/git/refs' . $namespace;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -92,10 +71,10 @@ class Refs extends AbstractPackage
 	 * @param   string  $ref   The name of the fully qualified reference.
 	 * @param   string  $sha   The SHA1 value to set this reference to.
 	 *
-	 * @throws DomainException
-	 * @since  1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function create($user, $repo, $ref, $sha)
 	{
@@ -111,17 +90,7 @@ class Refs extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -133,10 +102,10 @@ class Refs extends AbstractPackage
 	 * @param   string   $sha    The SHA1 value to set the reference to.
 	 * @param   boolean  $force  Whether the update should be forced. Default to false.
 	 *
-	 * @throws DomainException
-	 * @since  1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  DomainException
 	 */
 	public function edit($user, $repo, $ref, $sha, $force = false)
 	{
@@ -158,17 +127,7 @@ class Refs extends AbstractPackage
 		$data = json_encode($data);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -178,8 +137,9 @@ class Refs extends AbstractPackage
 	 * @param   string  $repo   The name of the GitHub repository.
 	 * @param   string  $ref    The reference to update.
 	 *
+	 * @return  object
+	 *
 	 * @since   1.0
-	 * @return object
 	 */
 	public function delete($owner, $repo, $ref)
 	{

--- a/src/Package/Emojis.php
+++ b/src/Package/Emojis.php
@@ -22,10 +22,10 @@ class Emojis extends AbstractPackage
 	/**
 	 * Lists all the emojis available to use on GitHub.
 	 *
-	 * @return array
+	 * @return  array
 	 *
-	 * @since  1.1
-	 * @throws \DomainException
+	 * @since   1.1
+	 * @throws  \DomainException
 	 */
 	public function getList()
 	{
@@ -33,16 +33,6 @@ class Emojis extends AbstractPackage
 		$path = '/emojis';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 }

--- a/src/Package/Gists.php
+++ b/src/Package/Gists.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github\Package;
 
 use Joomla\Github\AbstractPackage;
+use Joomla\Http\Exception\UnexpectedResponseException;
 
 /**
  * GitHub API Gists class for the Joomla Framework.
@@ -48,17 +49,7 @@ class Gists extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -77,15 +68,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/' . (int) $gistId;
 
 		// Send the request.
-		$response = $this->client->delete($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 204)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+		$this->processResponse($this->client->delete($this->fetchUrl($path)), 204);
 	}
 
 	/**
@@ -131,17 +114,7 @@ class Gists extends AbstractPackage
 		$data = json_encode($data);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -179,17 +152,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/' . (int) $gistId;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -231,17 +194,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/' . (int) $gistId . '/forks';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -264,17 +217,7 @@ class Gists extends AbstractPackage
 		$path = '/gists';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -295,17 +238,7 @@ class Gists extends AbstractPackage
 		$path = '/users/' . $user . '/gists';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -325,17 +258,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/public';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -355,17 +278,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/starred';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -396,7 +309,7 @@ class Gists extends AbstractPackage
 	 * @return  boolean  True if gist is starred
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	public function isStarred($gistId)
 	{
@@ -411,16 +324,16 @@ class Gists extends AbstractPackage
 		{
 			return true;
 		}
-		elseif ($response->code == 404)
+
+		if ($response->code == 404)
 		{
 			return false;
 		}
-		else
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+
+		// Decode the error response and throw an exception.
+		$error = json_decode($response->body);
+		$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
+		throw new UnexpectedResponseException($response, $message, $response->code);
 	}
 
 	/**
@@ -439,15 +352,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/' . (int) $gistId . '/star';
 
 		// Send the request.
-		$response = $this->client->put($this->fetchUrl($path), '');
-
-		// Validate the response code.
-		if ($response->code != 204)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+		$this->processResponse($this->client->put($this->fetchUrl($path), ''), 204);
 	}
 
 	/**
@@ -466,15 +371,7 @@ class Gists extends AbstractPackage
 		$path = '/gists/' . (int) $gistId . '/star';
 
 		// Send the request.
-		$response = $this->client->delete($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 204)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+		$this->processResponse($this->client->delete($this->fetchUrl($path)), 204);
 	}
 
 	/**
@@ -497,14 +394,12 @@ class Gists extends AbstractPackage
 			if (!is_numeric($key))
 			{
 				// If the key isn't numeric, then we are dealing with a file whose content has been supplied
-
 				$data[$key] = array('content' => $file);
 			}
 			elseif (!file_exists($file))
 			{
 				// Otherwise, we have been given a path and we have to load the content
 				// Verify that the each file exists.
-
 				throw new \InvalidArgumentException('The file ' . $file . ' does not exist.');
 			}
 			else

--- a/src/Package/Gists/Comments.php
+++ b/src/Package/Gists/Comments.php
@@ -25,10 +25,10 @@ class Comments extends AbstractPackage
 	 * @param   integer  $gistId  The gist number.
 	 * @param   string   $body    The comment body text.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function create($gistId, $body)
 	{
@@ -43,17 +43,7 @@ class Comments extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -61,10 +51,10 @@ class Comments extends AbstractPackage
 	 *
 	 * @param   integer  $commentId  The id of the comment to delete.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
-	 *
 	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function delete($commentId)
 	{
@@ -72,15 +62,7 @@ class Comments extends AbstractPackage
 		$path = '/gists/comments/' . (int) $commentId;
 
 		// Send the request.
-		$response = $this->client->delete($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 204)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+		$this->processResponse($this->client->delete($this->fetchUrl($path)), 204);
 	}
 
 	/**
@@ -89,10 +71,10 @@ class Comments extends AbstractPackage
 	 * @param   integer  $commentId  The id of the comment to update.
 	 * @param   string   $body       The new body text for the comment.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function edit($commentId, $body)
 	{
@@ -107,17 +89,7 @@ class Comments extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -125,10 +97,10 @@ class Comments extends AbstractPackage
 	 *
 	 * @param   integer  $commentId  The comment id to get.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function get($commentId)
 	{
@@ -136,17 +108,7 @@ class Comments extends AbstractPackage
 		$path = '/gists/comments/' . (int) $commentId;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -156,10 +118,10 @@ class Comments extends AbstractPackage
 	 * @param   integer  $page    The page number from which to get items.
 	 * @param   integer  $limit   The number of items on a page.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function getList($gistId, $page = 0, $limit = 0)
 	{
@@ -167,16 +129,6 @@ class Comments extends AbstractPackage
 		$path = '/gists/' . (int) $gistId . '/comments';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 }

--- a/src/Package/Gitignore.php
+++ b/src/Package/Gitignore.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github\Package;
 
 use Joomla\Github\AbstractPackage;
+use Joomla\Http\Exception\UnexpectedResponseException;
 
 /**
  * GitHub API Gitignore class for the Joomla Framework.
@@ -50,7 +51,7 @@ class Gitignore extends AbstractPackage
 	 * @return  mixed|string
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	public function get($name, $raw = false)
 	{
@@ -70,10 +71,9 @@ class Gitignore extends AbstractPackage
 		if ($response->code != 200)
 		{
 			// Decode the error response and throw an exception.
-			$error   = json_decode($response->body);
-			$message = (isset($error->message)) ? $error->message : 'Invalid response';
-
-			throw new \DomainException($message, $response->code);
+			$error = json_decode($response->body);
+			$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
+			throw new UnexpectedResponseException($response, $message, $response->code);
 		}
 
 		return ($raw) ? $response->body : json_decode($response->body);

--- a/src/Package/Issues.php
+++ b/src/Package/Issues.php
@@ -66,17 +66,7 @@ class Issues extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -151,17 +141,7 @@ class Issues extends AbstractPackage
 		$data = json_encode($data);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -182,17 +162,7 @@ class Issues extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/issues/' . (int) $issueId;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -251,17 +221,7 @@ class Issues extends AbstractPackage
 		}
 
 		// Send the request.
-		$response = $this->client->get((string) $uri);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get((string) $uri));
 	}
 
 	/**
@@ -334,17 +294,7 @@ class Issues extends AbstractPackage
 		}
 
 		// Send the request.
-		$response = $this->client->get((string) $uri);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get((string) $uri));
 	}
 
 	/**

--- a/src/Package/Issues/Assignees.php
+++ b/src/Package/Issues/Assignees.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github\Package\Issues;
 
 use Joomla\Github\AbstractPackage;
+use Joomla\Http\Exception\UnexpectedResponseException;
 
 /**
  * GitHub API Assignees class for the Joomla Framework.
@@ -27,7 +28,9 @@ class Assignees extends AbstractPackage
 	 * @param   string  $owner  The name of the owner of the GitHub repository.
 	 * @param   string  $repo   The name of the GitHub repository.
 	 *
-	 * @return object
+	 * @return  object
+	 *
+	 * @since   1.0
 	 */
 	public function getList($owner, $repo)
 	{
@@ -51,8 +54,10 @@ class Assignees extends AbstractPackage
 	 * @param   string  $repo      The name of the GitHub repository.
 	 * @param   string  $assignee  The assignees login name.
 	 *
-	 * @throws \DomainException|\Exception
-	 * @return boolean
+	 * @return  boolean
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function check($owner, $repo, $assignee)
 	{
@@ -68,7 +73,7 @@ class Assignees extends AbstractPackage
 				return true;
 			}
 
-			throw new \DomainException('Invalid response: ' . $response->code);
+			throw new UnexpectedResponseException($response, 'Invalid response: ' . $response->code);
 		}
 		catch (\DomainException $e)
 		{

--- a/src/Package/Issues/Labels.php
+++ b/src/Package/Issues/Labels.php
@@ -89,17 +89,7 @@ class Labels extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**

--- a/src/Package/Issues/Milestones.php
+++ b/src/Package/Issues/Milestones.php
@@ -30,10 +30,10 @@ class Milestones extends AbstractPackage
 	 * @param   integer  $page       The page number from which to get items.
 	 * @param   integer  $limit      The number of items on a page.
 	 *
-	 * @throws \DomainException
-	 * @since   1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function getList($user, $repo, $state = 'open', $sort = 'due_date', $direction = 'desc', $page = 0, $limit = 0)
 	{
@@ -45,17 +45,7 @@ class Milestones extends AbstractPackage
 		$path .= '&direction=' . $direction;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -65,10 +55,10 @@ class Milestones extends AbstractPackage
 	 * @param   string   $repo         The name of the GitHub repository.
 	 * @param   integer  $milestoneId  The milestone id to get.
 	 *
-	 * @throws \DomainException
 	 * @return  object
 	 *
 	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function get($user, $repo, $milestoneId)
 	{
@@ -76,17 +66,7 @@ class Milestones extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/milestones/' . (int) $milestoneId;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -99,10 +79,10 @@ class Milestones extends AbstractPackage
 	 * @param   string   $description  Optional description for milestone.
 	 * @param   string   $due_on       Optional ISO 8601 time.
 	 *
-	 * @throws \DomainException
 	 * @return  object
 	 *
 	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function create($user, $repo, $title, $state = null, $description = null, $due_on = null)
 	{
@@ -132,17 +112,7 @@ class Milestones extends AbstractPackage
 		$data = json_encode($data);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -156,10 +126,10 @@ class Milestones extends AbstractPackage
 	 * @param   string   $description  Optional description for milestone.
 	 * @param   string   $due_on       Optional ISO 8601 time.
 	 *
-	 * @throws \DomainException
 	 * @return  object
 	 *
 	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function edit($user, $repo, $milestoneId, $title = null, $state = null, $description = null, $due_on = null)
 	{
@@ -192,17 +162,7 @@ class Milestones extends AbstractPackage
 		$data = json_encode($data);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -212,10 +172,10 @@ class Milestones extends AbstractPackage
 	 * @param   string   $repo         The name of the GitHub repository.
 	 * @param   integer  $milestoneId  The id of the milestone to delete.
 	 *
-	 * @throws \DomainException
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function delete($user, $repo, $milestoneId)
 	{
@@ -223,14 +183,6 @@ class Milestones extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/milestones/' . (int) $milestoneId;
 
 		// Send the request.
-		$response = $this->client->delete($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 204)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+		$this->processResponse($this->client->delete($this->fetchUrl($path)), 204);
 	}
 }

--- a/src/Package/Markdown.php
+++ b/src/Package/Markdown.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github\Package;
 
 use Joomla\Github\AbstractPackage;
+use Joomla\Http\Exception\UnexpectedResponseException;
 
 /**
  * GitHub API Markdown class.
@@ -29,7 +30,7 @@ class Markdown extends AbstractPackage
 	 * @return  string  Formatted HTML
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 * @throws  \InvalidArgumentException
 	 */
 	public function render($text, $mode = 'gfm', $context = null)
@@ -64,8 +65,8 @@ class Markdown extends AbstractPackage
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			$message = (isset($error->message)) ? $error->message : 'Error: ' . $response->code;
-			throw new \DomainException($message, $response->code);
+			$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
+			throw new UnexpectedResponseException($response, $message, $response->code);
 		}
 
 		return $response->body;

--- a/src/Package/Pulls.php
+++ b/src/Package/Pulls.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github\Package;
 
 use Joomla\Github\AbstractPackage;
+use Joomla\Http\Exception\UnexpectedResponseException;
 
 /**
  * GitHub API Pull Requests class for the Joomla Framework.
@@ -55,17 +56,7 @@ class Pulls extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -100,17 +91,7 @@ class Pulls extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->post($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 201)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->post($this->fetchUrl($path), $data), 201);
 	}
 
 	/**
@@ -158,17 +139,7 @@ class Pulls extends AbstractPackage
 		$data = json_encode($data);
 
 		// Send the request.
-		$response = $this->client->patch($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->patch($this->fetchUrl($path), $data));
 	}
 
 	/**
@@ -189,17 +160,7 @@ class Pulls extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/pulls/' . (int) $pullId;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -211,7 +172,7 @@ class Pulls extends AbstractPackage
 	 * @param   integer  $page    The page number from which to get items.
 	 * @param   integer  $limit   The number of items on a page.
 	 *
-	 * @return  array
+	 * @return  object
 	 *
 	 * @since   1.0
 	 * @throws  \DomainException
@@ -222,17 +183,7 @@ class Pulls extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/pulls/' . (int) $pullId . '/commits';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -244,7 +195,7 @@ class Pulls extends AbstractPackage
 	 * @param   integer  $page    The page number from which to get items.
 	 * @param   integer  $limit   The number of items on a page.
 	 *
-	 * @return  array
+	 * @return  object
 	 *
 	 * @since   1.0
 	 * @throws  \DomainException
@@ -255,17 +206,7 @@ class Pulls extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/pulls/' . (int) $pullId . '/files';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -294,17 +235,7 @@ class Pulls extends AbstractPackage
 		}
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path, $page, $limit)));
 	}
 
 	/**
@@ -317,7 +248,7 @@ class Pulls extends AbstractPackage
 	 * @return  boolean  True if the pull request has been merged
 	 *
 	 * @since   1.0
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	public function isMerged($user, $repo, $pullId)
 	{
@@ -332,16 +263,16 @@ class Pulls extends AbstractPackage
 		{
 			return true;
 		}
-		elseif ($response->code == 404)
+
+		if ($response->code == 404)
 		{
 			return false;
 		}
-		else
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
+
+		// Decode the error response and throw an exception.
+		$error = json_decode($response->body);
+		$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
+		throw new UnexpectedResponseException($response, $message, $response->code);
 	}
 
 	/**
@@ -370,16 +301,6 @@ class Pulls extends AbstractPackage
 		);
 
 		// Send the request.
-		$response = $this->client->put($this->fetchUrl($path), $data);
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->put($this->fetchUrl($path), $data));
 	}
 }

--- a/src/Package/Repositories/Commits.php
+++ b/src/Package/Repositories/Commits.php
@@ -10,6 +10,7 @@ namespace Joomla\Github\Package\Repositories;
 
 use Joomla\Github\AbstractPackage;
 use Joomla\Date\Date;
+use Joomla\Http\Exception\UnexpectedResponseException;
 
 /**
  * GitHub API Repositories Commits class for the Joomla Framework.
@@ -36,10 +37,10 @@ class Commits extends AbstractPackage
 	 * @param   Date    $since   ISO 8601 Date - Only commits after this date will be returned.
 	 * @param   Date    $until   ISO 8601 Date - Only commits before this date will be returned.
 	 *
-	 * @throws \DomainException
-	 * @since    1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function getList($user, $repo, $sha = '', $path = '', $author = '', Date $since = null, Date $until = null)
 	{
@@ -53,17 +54,7 @@ class Commits extends AbstractPackage
 		$rPath .= ($until) ? '&until=' . $until->toISO8601() : '';
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($rPath));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($rPath)));
 	}
 
 	/**
@@ -73,10 +64,10 @@ class Commits extends AbstractPackage
 	 * @param   string  $repo  The name of the GitHub repository.
 	 * @param   string  $sha   The SHA of the commit to retrieve.
 	 *
-	 * @throws \DomainException
-	 * @since   1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function get($user, $repo, $sha)
 	{
@@ -84,17 +75,7 @@ class Commits extends AbstractPackage
 		$path = '/repos/' . $user . '/' . $repo . '/commits/' . $sha;
 
 		// Send the request.
-		$response = $this->client->get($this->fetchUrl($path));
-
-		// Validate the response code.
-		if ($response->code != 200)
-		{
-			// Decode the error response and throw an exception.
-			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
-		}
-
-		return json_decode($response->body);
+		return $this->processResponse($this->client->get($this->fetchUrl($path)));
 	}
 
 	/**
@@ -104,10 +85,10 @@ class Commits extends AbstractPackage
 	 * @param   string  $repo  The name of the GitHub repository.
 	 * @param   string  $ref   The commit reference
 	 *
-	 * @return  array
+	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
-	 * @throws  \DomainException
+	 * @throws  UnexpectedResponseException
 	 */
 	public function getSha($user, $repo, $ref)
 	{
@@ -122,7 +103,8 @@ class Commits extends AbstractPackage
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new \DomainException($error->message, $response->code);
+			$message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
+			throw new UnexpectedResponseException($response, $message, $response->code);
 		}
 
 		return $response->body;
@@ -136,7 +118,7 @@ class Commits extends AbstractPackage
 	 * @param   string  $base  The base of the diff, either a commit SHA or branch.
 	 * @param   string  $head  The head of the diff, either a commit SHA or branch.
 	 *
-	 * @return  array
+	 * @return  object
 	 *
 	 * @since   1.0
 	 */

--- a/src/Package/Repositories/Statistics.php
+++ b/src/Package/Repositories/Statistics.php
@@ -39,9 +39,9 @@ class Statistics  extends AbstractPackage
 	 * @param   string  $owner  The owner of the repository.
 	 * @param   string  $repo   The repository name.
 	 *
-	 * @since   1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
 	 */
 	public function getListContributors($owner, $repo)
 	{
@@ -61,9 +61,9 @@ class Statistics  extends AbstractPackage
 	 * @param   string  $owner  The owner of the repository.
 	 * @param   string  $repo   The repository name.
 	 *
-	 * @since   1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
 	 */
 	public function getActivityData($owner, $repo)
 	{
@@ -82,9 +82,9 @@ class Statistics  extends AbstractPackage
 	 * @param   string  $owner  The owner of the repository.
 	 * @param   string  $repo   The repository name.
 	 *
-	 * @since   1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
 	 */
 	public function getCodeFrequency($owner, $repo)
 	{
@@ -107,9 +107,9 @@ class Statistics  extends AbstractPackage
 	 * @param   string  $owner  The owner of the repository.
 	 * @param   string  $repo   The repository name.
 	 *
-	 * @since   1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
 	 */
 	public function getParticipation($owner, $repo)
 	{
@@ -136,9 +136,9 @@ class Statistics  extends AbstractPackage
 	 * @param   string  $owner  The owner of the repository.
 	 * @param   string  $repo   The repository name.
 	 *
-	 * @since   1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
 	 */
 	public function getPunchCard($owner, $repo)
 	{


### PR DESCRIPTION
Changes the `processResponse()` method to throw a [UnexpectedResponseException](https://github.com/joomla-framework/http/blob/master/src/Exception/UnexpectedResponseException.php) (provided by the HTTP package) which allows the full Response object to be attached to the exception for debugging purposes.

Standardizes all code (as able) to use `processResponse()` versus the internal checks that existed before this method was implemented.

Minor doc block standardizing.