### PR TITLE
Remove joomla/date dependency

### DIFF
--- a/Tests/Package/Activity/NotificationsTest.php
+++ b/Tests/Package/Activity/NotificationsTest.php
@@ -8,7 +8,6 @@ namespace Joomla\Github\Tests;
 
 use Joomla\Github\Package\Activity\Notifications;
 use Joomla\Registry\Registry;
-use Joomla\Date\Date;
 
 /**
  * Test class for the GitHub API package.
@@ -145,7 +144,7 @@ class NotificationsTest extends \PHPUnit_Framework_TestCase
 		$this->response->code = 205;
 		$this->response->body = '';
 
-		$date = new Date('1966-09-14');
+		$date = new \DateTime('1966-09-14', new \DateTimeZone('UTC'));
 		$data = '{"unread":true,"read":true,"last_read_at":"1966-09-14T00:00:00+00:00"}';
 
 		$this->client->expects($this->once())
@@ -192,7 +191,7 @@ class NotificationsTest extends \PHPUnit_Framework_TestCase
 		$this->response->code = 205;
 		$this->response->body = '';
 
-		$date = new Date('1966-09-14');
+		$date = new \DateTime('1966-09-14', new \DateTimeZone('UTC'));
 		$data = '{"unread":true,"read":true,"last_read_at":"1966-09-14T00:00:00+00:00"}';
 
 		$this->client->expects($this->once())

--- a/Tests/Package/Issues/CommentsTest.php
+++ b/Tests/Package/Issues/CommentsTest.php
@@ -8,7 +8,6 @@ namespace Joomla\Github\Tests\Issues;
 
 use Joomla\Github\Package\Issues\Comments;
 use Joomla\Registry\Registry;
-use Joomla\Date\Date;
 
 /**
  * Test class for the GitHub API package.
@@ -152,7 +151,7 @@ class CommentsTest extends \PHPUnit_Framework_TestCase
 		$this->response->code = 200;
 		$this->response->body = $this->sampleString;
 
-		$date = new Date('1966-09-15 12:34:56');
+		$date = new \DateTime('1966-09-15 12:34:56', new \DateTimeZone('UTC'));
 
 		$this->client->expects($this->once())
 			->method('get')

--- a/Tests/Package/IssuesTest.php
+++ b/Tests/Package/IssuesTest.php
@@ -8,7 +8,6 @@ namespace Joomla\Github\Tests;
 
 use Joomla\Github\Package\Issues;
 use Joomla\Registry\Registry;
-use Joomla\Date\Date;
 
 /**
  * Test class for Issues.
@@ -743,7 +742,7 @@ class IssuesTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetListByRepositoryAll()
 	{
-		$date = new Date('January 1, 2012 12:12:12');
+		$date = new \DateTime('January 1, 2012 12:12:12', new \DateTimeZone('UTC'));
 		$this->response->code = 200;
 		$this->response->body = $this->sampleString;
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.3.10|>=7.0",
-        "joomla/date": "~1.0",
         "joomla/http": "^1.2.2",
         "joomla/registry": "~1.0",
         "joomla/uri": "~1.0"

--- a/src/Package/Activity/Notifications.php
+++ b/src/Package/Activity/Notifications.php
@@ -9,7 +9,6 @@
 namespace Joomla\Github\Package\Activity;
 
 use Joomla\Github\AbstractPackage;
-use Joomla\Date\Date;
 
 /**
  * GitHub API Activity Events class for the Joomla Framework.
@@ -25,24 +24,23 @@ class Notifications extends AbstractPackage
 	 *
 	 * List all notifications for the current user, grouped by repository.
 	 *
-	 * @param   boolean  $all            True to show notifications marked as read.
-	 * @param   boolean  $participating  True to show only notifications in which the user is directly participating or
-	 *                                   mentioned.
-	 * @param   Date     $since          filters out any notifications updated before the given time. The time should be passed in
-	 *                                   as UTC in the ISO 8601 format.
+	 * @param   boolean    $all            True to show notifications marked as read.
+	 * @param   boolean    $participating  True to show only notifications in which the user is directly participating or mentioned.
+	 * @param   \DateTime  $since          Filters out any notifications updated before the given time. The time should be passed in
+	 *                                     as UTC in the ISO 8601 format.
 	 *
 	 * @return  object
 	 *
 	 * @since   1.0
 	 */
-	public function getList($all = true, $participating = true, Date $since = null)
+	public function getList($all = true, $participating = true, \DateTime $since = null)
 	{
 		// Build the request path.
 		$path = '/notifications?';
 
 		$path .= ($all) ? '&all=1' : '';
 		$path .= ($participating) ? '&participating=1' : '';
-		$path .= ($since) ? '&since=' . $since->toISO8601() : '';
+		$path .= ($since) ? '&since=' . $since->format(\DateTime::RFC3339) : '';
 
 		return $this->processResponse(
 			$this->client->get($this->fetchUrl($path))
@@ -54,26 +52,25 @@ class Notifications extends AbstractPackage
 	 *
 	 * List all notifications for the current user.
 	 *
-	 * @param   string   $owner          Repository owner.
-	 * @param   string   $repo           Repository name.
-	 * @param   boolean  $all            True to show notifications marked as read.
-	 * @param   boolean  $participating  True to show only notifications in which the user is directly participating or
-	 *                                   mentioned.
-	 * @param   Date     $since          filters out any notifications updated before the given time. The time should be passed in
-	 *                                   as UTC in the ISO 8601 format.
+	 * @param   string     $owner          Repository owner.
+	 * @param   string     $repo           Repository name.
+	 * @param   boolean    $all            True to show notifications marked as read.
+	 * @param   boolean    $participating  True to show only notifications in which the user is directly participating or mentioned.
+	 * @param   \DateTime  $since          Filters out any notifications updated before the given time. The time should be passed in
+	 *                                     as UTC in the ISO 8601 format.
 	 *
 	 * @return  object
 	 *
 	 * @since   1.0
 	 */
-	public function getListRepository($owner, $repo, $all = true, $participating = true, Date $since = null)
+	public function getListRepository($owner, $repo, $all = true, $participating = true, \DateTime $since = null)
 	{
 		// Build the request path.
 		$path = '/repos/' . $owner . '/' . $repo . '/notifications?';
 
 		$path .= ($all) ? '&all=1' : '';
 		$path .= ($participating) ? '&participating=1' : '';
-		$path .= ($since) ? '&since=' . $since->toISO8601() : '';
+		$path .= ($since) ? '&since=' . $since->format(\DateTime::RFC3339) : '';
 
 		return $this->processResponse(
 			$this->client->get($this->fetchUrl($path))
@@ -85,16 +82,16 @@ class Notifications extends AbstractPackage
 	 *
 	 * Marking a notification as “read” removes it from the default view on GitHub.com.
 	 *
-	 * @param   boolean  $unread        Changes the unread status of the threads.
-	 * @param   boolean  $read          Inverse of “unread”.
-	 * @param   Date     $last_read_at  Describes the last point that notifications were checked.
+	 * @param   boolean    $unread      Changes the unread status of the threads.
+	 * @param   boolean    $read        Inverse of “unread”.
+	 * @param   \DateTime  $lastReadAt  Describes the last point that notifications were checked.
 	 *                                  Anything updated since this time will not be updated. Default: Now. Expected in ISO 8601 format.
 	 *
 	 * @return  object
 	 *
 	 * @since   1.0
 	 */
-	public function markRead($unread = true, $read = true, Date $last_read_at = null)
+	public function markRead($unread = true, $read = true, \DateTime $lastReadAt = null)
 	{
 		// Build the request path.
 		$path = '/notifications';
@@ -104,9 +101,9 @@ class Notifications extends AbstractPackage
 			'read'   => $read
 		);
 
-		if ($last_read_at)
+		if ($lastReadAt)
 		{
-			$data['last_read_at'] = $last_read_at->toISO8601();
+			$data['last_read_at'] = $lastReadAt->format(\DateTime::RFC3339);
 		}
 
 		return $this->processResponse(
@@ -120,18 +117,18 @@ class Notifications extends AbstractPackage
 	 *
 	 * Marking all notifications in a repository as “read” removes them from the default view on GitHub.com.
 	 *
-	 * @param   string   $owner         Repository owner.
-	 * @param   string   $repo          Repository name.
-	 * @param   boolean  $unread        Changes the unread status of the threads.
-	 * @param   boolean  $read          Inverse of “unread”.
-	 * @param   Date     $last_read_at  Describes the last point that notifications were checked.
+	 * @param   string     $owner       Repository owner.
+	 * @param   string     $repo        Repository name.
+	 * @param   boolean    $unread      Changes the unread status of the threads.
+	 * @param   boolean    $read        Inverse of “unread”.
+	 * @param   \DateTime  $lastReadAt  Describes the last point that notifications were checked.
 	 *                                  Anything updated since this time will not be updated. Default: Now. Expected in ISO 8601 format.
 	 *
 	 * @return  object
 	 *
 	 * @since   1.0
 	 */
-	public function markReadRepository($owner, $repo, $unread, $read, Date $last_read_at = null)
+	public function markReadRepository($owner, $repo, $unread, $read, \DateTime $lastReadAt = null)
 	{
 		// Build the request path.
 		$path = '/repos/' . $owner . '/' . $repo . '/notifications';
@@ -141,9 +138,9 @@ class Notifications extends AbstractPackage
 			'read'   => $read
 		);
 
-		if ($last_read_at)
+		if ($lastReadAt)
 		{
-			$data['last_read_at'] = $last_read_at->toISO8601();
+			$data['last_read_at'] = $lastReadAt->format(\DateTime::RFC3339);
 		}
 
 		return $this->processResponse(

--- a/src/Package/Issues.php
+++ b/src/Package/Issues.php
@@ -9,7 +9,6 @@
 namespace Joomla\Github\Package;
 
 use Joomla\Github\AbstractPackage;
-use Joomla\Date\Date;
 use Joomla\Uri\Uri;
 
 /**
@@ -198,14 +197,14 @@ class Issues extends AbstractPackage
 	/**
 	 * List issues.
 	 *
-	 * @param   string   $filter     The filter type: assigned, created, mentioned, subscribed.
-	 * @param   string   $state      The optional state to filter requests by. [open, closed]
-	 * @param   string   $labels     The list of comma separated Label names. Example: bug,ui,@high.
-	 * @param   string   $sort       The sort order: created, updated, comments, default: created.
-	 * @param   string   $direction  The list direction: asc or desc, default: desc.
-	 * @param   Date     $since      The date/time since when issues should be returned.
-	 * @param   integer  $page       The page number from which to get items.
-	 * @param   integer  $limit      The number of items on a page.
+	 * @param   string     $filter     The filter type: assigned, created, mentioned, subscribed.
+	 * @param   string     $state      The optional state to filter requests by. [open, closed]
+	 * @param   string     $labels     The list of comma separated Label names. Example: bug,ui,@high.
+	 * @param   string     $sort       The sort order: created, updated, comments, default: created.
+	 * @param   string     $direction  The list direction: asc or desc, default: desc.
+	 * @param   \DateTime  $since      The date/time since when issues should be returned.
+	 * @param   integer    $page       The page number from which to get items.
+	 * @param   integer    $limit      The number of items on a page.
 	 *
 	 * @return  object
 	 *
@@ -213,7 +212,7 @@ class Issues extends AbstractPackage
 	 * @throws  \DomainException
 	 */
 	public function getList($filter = null, $state = null, $labels = null, $sort = null,
-		$direction = null, Date $since = null, $page = 0, $limit = 0)
+		$direction = null, \DateTime $since = null, $page = 0, $limit = 0)
 	{
 		// Build the request path.
 		$path = '/issues';
@@ -267,18 +266,18 @@ class Issues extends AbstractPackage
 	/**
 	 * List issues for a repository.
 	 *
-	 * @param   string   $user       The name of the owner of the GitHub repository.
-	 * @param   string   $repo       The name of the GitHub repository.
-	 * @param   string   $milestone  The milestone number, 'none', or *.
-	 * @param   string   $state      The optional state to filter requests by. [open, closed]
-	 * @param   string   $assignee   The assignee name, 'none', or *.
-	 * @param   string   $mentioned  The GitHub user name.
-	 * @param   string   $labels     The list of comma separated Label names. Example: bug,ui,@high.
-	 * @param   string   $sort       The sort order: created, updated, comments, default: created.
-	 * @param   string   $direction  The list direction: asc or desc, default: desc.
-	 * @param   Date     $since      The date/time since when issues should be returned.
-	 * @param   integer  $page       The page number from which to get items.
-	 * @param   integer  $limit      The number of items on a page.
+	 * @param   string     $user       The name of the owner of the GitHub repository.
+	 * @param   string     $repo       The name of the GitHub repository.
+	 * @param   string     $milestone  The milestone number, 'none', or *.
+	 * @param   string     $state      The optional state to filter requests by. [open, closed]
+	 * @param   string     $assignee   The assignee name, 'none', or *.
+	 * @param   string     $mentioned  The GitHub user name.
+	 * @param   string     $labels     The list of comma separated Label names. Example: bug,ui,@high.
+	 * @param   string     $sort       The sort order: created, updated, comments, default: created.
+	 * @param   string     $direction  The list direction: asc or desc, default: desc.
+	 * @param   \DateTime  $since      The date/time since when issues should be returned.
+	 * @param   integer    $page       The page number from which to get items.
+	 * @param   integer    $limit      The number of items on a page.
 	 *
 	 * @return  object
 	 *
@@ -286,7 +285,7 @@ class Issues extends AbstractPackage
 	 * @throws  \DomainException
 	 */
 	public function getListByRepository($user, $repo, $milestone = null, $state = null, $assignee = null, $mentioned = null, $labels = null,
-		$sort = null, $direction = null, Date $since = null, $page = 0, $limit = 0)
+		$sort = null, $direction = null, \DateTime $since = null, $page = 0, $limit = 0)
 	{
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/issues';
@@ -330,7 +329,7 @@ class Issues extends AbstractPackage
 
 		if ($since)
 		{
-			$uri->setVar('since', $since->toISO8601());
+			$uri->setVar('since', $since->format(\DateTime::RFC3339));
 		}
 
 		// Send the request.

--- a/src/Package/Issues/Comments.php
+++ b/src/Package/Issues/Comments.php
@@ -9,7 +9,6 @@
 namespace Joomla\Github\Package\Issues;
 
 use Joomla\Github\AbstractPackage;
-use Joomla\Date\Date;
 
 /**
  * GitHub API Comments class for the Joomla Framework.
@@ -32,10 +31,10 @@ class Comments extends AbstractPackage
 	 * @param   integer  $page     The page number from which to get items.
 	 * @param   integer  $limit    The number of items on a page.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function getList($owner, $repo, $issueId, $page = 0, $limit = 0)
 	{
@@ -51,19 +50,19 @@ class Comments extends AbstractPackage
 	/**
 	 * List comments in a repository.
 	 *
-	 * @param   string  $owner      The name of the owner of the GitHub repository.
-	 * @param   string  $repo       The name of the GitHub repository.
-	 * @param   string  $sort       The sort field - created or updated.
-	 * @param   string  $direction  The sort order- asc or desc. Ignored without sort parameter.
-	 * @param   Date    $since      A timestamp in ISO 8601 format.
+	 * @param   string     $owner      The name of the owner of the GitHub repository.
+	 * @param   string     $repo       The name of the GitHub repository.
+	 * @param   string     $sort       The sort field - created or updated.
+	 * @param   string     $direction  The sort order- asc or desc. Ignored without sort parameter.
+	 * @param   \DateTime  $since      A timestamp in ISO 8601 format.
 	 *
-	 * @throws \UnexpectedValueException
-	 * @throws \DomainException
-	 * @since  1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \UnexpectedValueException
+	 * @throws  \DomainException
 	 */
-	public function getRepositoryList($owner, $repo, $sort = 'created', $direction = 'asc', Date $since = null)
+	public function getRepositoryList($owner, $repo, $sort = 'created', $direction = 'asc', \DateTime $since = null)
 	{
 		// Build the request path.
 		$path = '/repos/' . $owner . '/' . $repo . '/issues/comments';
@@ -91,7 +90,7 @@ class Comments extends AbstractPackage
 
 		if ($since)
 		{
-			$path .= '&since=' . $since->toISO8601();
+			$path .= '&since=' . $since->format(\DateTime::RFC3339);
 		}
 
 		// Send the request.
@@ -105,7 +104,10 @@ class Comments extends AbstractPackage
 	 * @param   string   $repo   The name of the GitHub repository.
 	 * @param   integer  $id     The comment id.
 	 *
-	 * @return mixed
+	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function get($owner, $repo, $id)
 	{
@@ -126,10 +128,10 @@ class Comments extends AbstractPackage
 	 * @param   integer  $commentId  The id of the comment to update.
 	 * @param   string   $body       The new body text for the comment.
 	 *
-	 * @since  1.0
-	 * @throws \DomainException
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function edit($user, $repo, $commentId, $body)
 	{
@@ -157,10 +159,10 @@ class Comments extends AbstractPackage
 	 * @param   integer  $issueId  The issue number.
 	 * @param   string   $body     The comment body text.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
-	 *
 	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function create($user, $repo, $issueId, $body)
 	{
@@ -188,10 +190,10 @@ class Comments extends AbstractPackage
 	 * @param   string   $repo       The name of the GitHub repository.
 	 * @param   integer  $commentId  The id of the comment to delete.
 	 *
-	 * @throws \DomainException
-	 * @since  1.0
-	 *
 	 * @return  boolean
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function delete($user, $repo, $commentId)
 	{

--- a/src/Package/Repositories/Commits.php
+++ b/src/Package/Repositories/Commits.php
@@ -9,7 +9,6 @@
 namespace Joomla\Github\Package\Repositories;
 
 use Joomla\Github\AbstractPackage;
-use Joomla\Date\Date;
 
 /**
  * GitHub API Repositories Commits class for the Joomla Framework.
@@ -28,20 +27,20 @@ class Commits extends AbstractPackage
 	 * Please follow the link headers as outlined in the pagination overview instead of constructing
 	 * page links yourself.
 	 *
-	 * @param   string  $user    The name of the owner of the GitHub repository.
-	 * @param   string  $repo    The name of the GitHub repository.
-	 * @param   string  $sha     Sha or branch to start listing commits from.
-	 * @param   string  $path    Only commits containing this file path will be returned.
-	 * @param   string  $author  GitHub login, name, or email by which to filter by commit author.
-	 * @param   Date    $since   ISO 8601 Date - Only commits after this date will be returned.
-	 * @param   Date    $until   ISO 8601 Date - Only commits before this date will be returned.
+	 * @param   string     $user    The name of the owner of the GitHub repository.
+	 * @param   string     $repo    The name of the GitHub repository.
+	 * @param   string     $sha     Sha or branch to start listing commits from.
+	 * @param   string     $path    Only commits containing this file path will be returned.
+	 * @param   string     $author  GitHub login, name, or email by which to filter by commit author.
+	 * @param   \DateTime  $since   ISO 8601 Date - Only commits after this date will be returned.
+	 * @param   \DateTime  $until   ISO 8601 Date - Only commits before this date will be returned.
 	 *
-	 * @throws \DomainException
-	 * @since    1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
-	public function getList($user, $repo, $sha = '', $path = '', $author = '', Date $since = null, Date $until = null)
+	public function getList($user, $repo, $sha = '', $path = '', $author = '', \DateTime $since = null, \DateTime $until = null)
 	{
 		// Build the request path.
 		$rPath = '/repos/' . $user . '/' . $repo . '/commits?';
@@ -49,8 +48,8 @@ class Commits extends AbstractPackage
 		$rPath .= ($sha) ? '&sha=' . $sha : '';
 		$rPath .= ($path) ? '&path=' . $path : '';
 		$rPath .= ($author) ? '&author=' . $author : '';
-		$rPath .= ($since) ? '&since=' . $since->toISO8601() : '';
-		$rPath .= ($until) ? '&until=' . $until->toISO8601() : '';
+		$rPath .= ($since) ? '&since=' . $since->format(\DateTime::RFC3339) : '';
+		$rPath .= ($until) ? '&until=' . $until->format(\DateTime::RFC3339) : '';
 
 		// Send the request.
 		$response = $this->client->get($this->fetchUrl($rPath));
@@ -73,10 +72,10 @@ class Commits extends AbstractPackage
 	 * @param   string  $repo  The name of the GitHub repository.
 	 * @param   string  $sha   The SHA of the commit to retrieve.
 	 *
-	 * @throws \DomainException
-	 * @since   1.0
+	 * @return  object
 	 *
-	 * @return  array
+	 * @since   1.0
+	 * @throws  \DomainException
 	 */
 	public function get($user, $repo, $sha)
 	{
@@ -136,7 +135,7 @@ class Commits extends AbstractPackage
 	 * @param   string  $base  The base of the diff, either a commit SHA or branch.
 	 * @param   string  $head  The head of the diff, either a commit SHA or branch.
 	 *
-	 * @return  array
+	 * @return  object
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
The only real benefit the `joomla/date` package dependency gives is the enforcement of UTC timezoned `DateTime` objects.  IMO while convenient, it doesn't stand to mandate this specific subclass of `DateTime` should be required.  So the signatures are changed to allow all `DateTime` objects and the `joomla/date` dependency is removed.