### PR TITLE
Use `@link` over `@see` and `@dokumentation` and move Links to https

### DIFF
--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -43,7 +43,7 @@ abstract class AbstractGithubObject
 	 *
 	 * @var    array
 	 * @since  1.5.2
-	 * @see    https://developer.github.com/webhooks/#events
+	 * @link   https://developer.github.com/webhooks/#events
 	 * @note   From 1.4.0 to 1.5.1 this was named $events, it was renamed due to naming conflicts with package subclasses
 	 */
 	protected $hookEvents = array(

--- a/src/Package/Activity/Events.php
+++ b/src/Package/Activity/Events.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Activity Events class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/activity/events/
+ * @link https://developer.github.com/v3/activity/events/
  *
  * @since  1.0
  */

--- a/src/Package/Activity/Notifications.php
+++ b/src/Package/Activity/Notifications.php
@@ -14,7 +14,7 @@ use Joomla\Uri\Uri;
 /**
  * GitHub API Activity Events class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/activity/notifications/
+ * @link https://developer.github.com/v3/activity/notifications/
  *
  * @since  1.0
  */

--- a/src/Package/Activity/Starring.php
+++ b/src/Package/Activity/Starring.php
@@ -14,7 +14,7 @@ use Joomla\Uri\Uri;
 /**
  * GitHub API Activity Events class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/activity/starring/
+ * @link https://developer.github.com/v3/activity/starring/
  *
  * @since  1.0
  */

--- a/src/Package/Activity/Watching.php
+++ b/src/Package/Activity/Watching.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Activity Watching Events class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/activity/watching/
+ * @link https://developer.github.com/v3/activity/watching/
  *
  * @since  1.0
  */

--- a/src/Package/Data.php
+++ b/src/Package/Data.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API DB class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/git/
+ * @link https://developer.github.com/v3/git/
  *
  * @since  1.0
  * http://developer.github.com/v3/git/

--- a/src/Package/Data/Blobs.php
+++ b/src/Package/Data/Blobs.php
@@ -17,7 +17,7 @@ use Joomla\Github\AbstractPackage;
  * takes an encoding parameter that can be either utf-8 or base64. If your data cannot be
  * losslessly sent as a UTF-8 string, you can base64 encode it.
  *
- * @documentation http://developer.github.com/v3/git/blobs/
+ * @link https://developer.github.com/v3/git/blobs/
  *
  * @since  1.0
  */

--- a/src/Package/Data/Commits.php
+++ b/src/Package/Data/Commits.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Data Commits class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/git/commits/
+ * @link https://developer.github.com/v3/git/commits/
  *
  * @since  1.0
  */

--- a/src/Package/Data/Refs.php
+++ b/src/Package/Data/Refs.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/git/refs/
+ * @link https://developer.github.com/v3/git/refs/
  *
  * @since  1.0
  */

--- a/src/Package/Data/Tags.php
+++ b/src/Package/Data/Tags.php
@@ -15,7 +15,7 @@ use Joomla\Github\AbstractPackage;
  *
  * This tags API only deals with tag objects - so only annotated tags, not lightweight tags.
  *
- * @documentation http://developer.github.com/v3/git/tags/
+ * @link https://developer.github.com/v3/git/tags/
  *
  * @since  1.0
  */

--- a/src/Package/Data/Trees.php
+++ b/src/Package/Data/Trees.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Data Trees class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/git/trees/
+ * @link https://developer.github.com/v3/git/trees/
  *
  * @since  1.0
  */

--- a/src/Package/Gists.php
+++ b/src/Package/Gists.php
@@ -14,7 +14,7 @@ use Joomla\Http\Exception\UnexpectedResponseException;
 /**
  * GitHub API Gists class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/gists
+ * @link https://developer.github.com/v3/gists
  *
  * @since  1.0
  *

--- a/src/Package/Gists/Comments.php
+++ b/src/Package/Gists/Comments.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Gists Comments class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/gists/comments/
+ * @link https://developer.github.com/v3/gists/comments/
  *
  * @since  1.0
  */

--- a/src/Package/Issues.php
+++ b/src/Package/Issues.php
@@ -14,7 +14,7 @@ use Joomla\Uri\Uri;
 /**
  * GitHub API Issues class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/issues
+ * @link https://developer.github.com/v3/issues
  *
  * @since  1.0
  *

--- a/src/Package/Issues/Assignees.php
+++ b/src/Package/Issues/Assignees.php
@@ -14,7 +14,7 @@ use Joomla\Http\Exception\UnexpectedResponseException;
 /**
  * GitHub API Assignees class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/issues/assignees/
+ * @link https://developer.github.com/v3/issues/assignees/
  *
  * @since  1.0
  */

--- a/src/Package/Issues/Comments.php
+++ b/src/Package/Issues/Comments.php
@@ -16,7 +16,7 @@ use Joomla\Github\AbstractPackage;
  * The Issue Comments API supports listing, viewing, editing, and creating comments
  * on issues and pull requests.
  *
- * @documentation http://developer.github.com/v3/issues/comments/
+ * @link https://developer.github.com/v3/issues/comments/
  *
  * @since  1.0
  */

--- a/src/Package/Issues/Events.php
+++ b/src/Package/Issues/Events.php
@@ -17,7 +17,7 @@ use Joomla\Github\AbstractPackage;
  * This is useful both for display on issue/pull request information pages and also
  * to determine who should be notified of comments.
  *
- * @documentation http://developer.github.com/v3/issues/events/
+ * @link https://developer.github.com/v3/issues/events/
  *
  * @since  1.0
  */

--- a/src/Package/Issues/Milestones.php
+++ b/src/Package/Issues/Milestones.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Milestones class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/issues/milestones/
+ * @link https://developer.github.com/v3/issues/milestones/
  *
  * @since  1.0
  */

--- a/src/Package/Markdown.php
+++ b/src/Package/Markdown.php
@@ -14,7 +14,7 @@ use Joomla\Http\Exception\UnexpectedResponseException;
 /**
  * GitHub API Markdown class.
  *
- * @documentation http://developer.github.com/v3/markdown
+ * @link https://developer.github.com/v3/markdown
  *
  * @since  1.0
  */

--- a/src/Package/Orgs/Hooks.php
+++ b/src/Package/Orgs/Hooks.php
@@ -16,7 +16,7 @@ use Joomla\Github\AbstractPackage;
  * All actions against organization webhooks require the authenticated user to be an admin of the organization being managed.
  * Additionally, OAuth tokens require the "admin:org_hook" scope.
  *
- * @documentation http://developer.github.com/v3/orgs/hooks/
+ * @link https://developer.github.com/v3/orgs/hooks/
  *
  * @since  1.4.0
  */

--- a/src/Package/Orgs/Members.php
+++ b/src/Package/Orgs/Members.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Orgs Members class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/orgs/members/
+ * @link https://developer.github.com/v3/orgs/members/
  *
  * @since  1.0
  */

--- a/src/Package/Orgs/Teams.php
+++ b/src/Package/Orgs/Teams.php
@@ -16,7 +16,7 @@ use Joomla\Github\AbstractPackage;
  * All actions against teams require at a minimum an authenticated user who is a member
  * of the owner’s team in the :org being managed. Additionally, OAuth users require “user” scope.
  *
- * @documentation http://developer.github.com/v3/orgs/teams/
+ * @link https://developer.github.com/v3/orgs/teams/
  *
  * @since  1.0
  */

--- a/src/Package/Pulls.php
+++ b/src/Package/Pulls.php
@@ -14,7 +14,7 @@ use Joomla\Http\Exception\UnexpectedResponseException;
 /**
  * GitHub API Pull Requests class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/pulls
+ * @link https://developer.github.com/v3/pulls
  *
  * @since  1.0
  *

--- a/src/Package/Pulls/Comments.php
+++ b/src/Package/Pulls/Comments.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Pulls Comments class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/pulls/comments/
+ * @link https://developer.github.com/v3/pulls/comments/
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Collaborators.php
+++ b/src/Package/Repositories/Collaborators.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Repositories Collaborators class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/collaborators
+ * @link https://developer.github.com/v3/repos/collaborators
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Comments.php
+++ b/src/Package/Repositories/Comments.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Repositories Comments class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/comments
+ * @link https://developer.github.com/v3/repos/comments
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Commits.php
+++ b/src/Package/Repositories/Commits.php
@@ -14,7 +14,7 @@ use Joomla\Http\Exception\UnexpectedResponseException;
 /**
  * GitHub API Repositories Commits class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/commits
+ * @link https://developer.github.com/v3/repos/commits
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Contents.php
+++ b/src/Package/Repositories/Contents.php
@@ -16,7 +16,7 @@ use Joomla\Github\AbstractPackage;
  * These API methods let you retrieve the contents of files within a repository as Base64 encoded content.
  * See media types for requesting raw or other formats.
  *
- * @documentation http://developer.github.com/v3/repos/contents
+ * @link https://developer.github.com/v3/repos/contents
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Forks.php
+++ b/src/Package/Repositories/Forks.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Forks class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/forks
+ * @link https://developer.github.com/v3/repos/forks
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Hooks.php
+++ b/src/Package/Repositories/Hooks.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Hooks class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/hooks
+ * @link https://developer.github.com/v3/repos/hooks
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Keys.php
+++ b/src/Package/Repositories/Keys.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Forks class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/keys
+ * @link https://developer.github.com/v3/repos/keys
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Merging.php
+++ b/src/Package/Repositories/Merging.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Repositories Merging class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/merging
+ * @link https://developer.github.com/v3/repos/merging
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Releases.php
+++ b/src/Package/Repositories/Releases.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/releases
+ * @link https://developer.github.com/v3/repos/releases
  *
  * @since  1.1.0
  */

--- a/src/Package/Repositories/Statistics.php
+++ b/src/Package/Repositories/Statistics.php
@@ -17,7 +17,7 @@ use Joomla\Http\Response;
  * The Repository Statistics API allows you to fetch the data that GitHub uses for
  * visualizing different types of repository activity.
  *
- * @documentation http://developer.github.com/v3/repos/statistics
+ * @link https://developer.github.com/v3/repos/statistics
  *
  * @since  1.0
  */

--- a/src/Package/Repositories/Statuses.php
+++ b/src/Package/Repositories/Statuses.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/statuses
+ * @link https://developer.github.com/v3/repos/statuses
  *
  * @since  1.0
  */

--- a/src/Package/Search.php
+++ b/src/Package/Search.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Search class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/search
+ * @link https://developer.github.com/v3/search
  *
  * @since  1.0
  */

--- a/src/Package/Users.php
+++ b/src/Package/Users.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/users
+ * @link https://developer.github.com/v3/repos/users
  *
  * @since  1.0
  *

--- a/src/Package/Users/Emails.php
+++ b/src/Package/Users/Emails.php
@@ -16,7 +16,7 @@ use Joomla\Github\AbstractPackage;
  * Management of email addresses via the API requires that you are authenticated
  * through basic auth or OAuth with the user scope.
  *
- * @documentation http://developer.github.com/v3/repos/users/emails
+ * @link https://developer.github.com/v3/repos/users/emails
  *
  * @since  1.0
  */

--- a/src/Package/Users/Followers.php
+++ b/src/Package/Users/Followers.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Followers class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/users/followers
+ * @link https://developer.github.com/v3/repos/users/followers
  *
  * @since  1.0
  */

--- a/src/Package/Users/Keys.php
+++ b/src/Package/Users/Keys.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Framework.
  *
- * @documentation http://developer.github.com/v3/repos/users/keys
+ * @link https://developer.github.com/v3/repos/users/keys
  *
  * @since  1.0
  */


### PR DESCRIPTION
### Summary of Changes

Use `@link` over `@see` and `@dokumentation` and move Links to https

### Testing Instructions

Review

### Documentation Changes Required

None