### PR TITLE
Fix the 404 Links pointing to github

### DIFF
--- a/src/Package/Users.php
+++ b/src/Package/Users.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Framework.
  *
- * @link   https://developer.github.com/v3/repos/users
+ * @link   https://developer.github.com/v3/users
  *
  * @since  1.0
  *

--- a/src/Package/Users/Emails.php
+++ b/src/Package/Users/Emails.php
@@ -16,7 +16,7 @@ use Joomla\Github\AbstractPackage;
  * Management of email addresses via the API requires that you are authenticated
  * through basic auth or OAuth with the user scope.
  *
- * @link   https://developer.github.com/v3/repos/users/emails
+ * @link   https://developer.github.com/v3/users/emails
  *
  * @since  1.0
  */

--- a/src/Package/Users/Followers.php
+++ b/src/Package/Users/Followers.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API Followers class for the Joomla Framework.
  *
- * @link   https://developer.github.com/v3/repos/users/followers
+ * @link   https://developer.github.com/v3/users/followers
  *
  * @since  1.0
  */

--- a/src/Package/Users/Keys.php
+++ b/src/Package/Users/Keys.php
@@ -13,7 +13,7 @@ use Joomla\Github\AbstractPackage;
 /**
  * GitHub API References class for the Joomla Framework.
  *
- * @link   https://developer.github.com/v3/repos/users/keys
+ * @link   https://developer.github.com/v3/users/keys
  *
  * @since  1.0
  */


### PR DESCRIPTION
### Summary of Changes

Some links in the inline doku for JGithub Point to 404 on github.com

### Testing Instructions

review as no production code is changed

### Expected result

no 404 links

### Actual result

404 links

### Additional comments

see here for the downstream PR: https://github.com/joomla/joomla-cms/pull/19775
