### PR TITLE
Deprecate Http subclass

### DIFF
--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -9,6 +9,7 @@
 namespace Joomla\Github;
 
 use Joomla\Http\Exception\UnexpectedResponseException;
+use Joomla\Http\Http as BaseHttp;
 use Joomla\Http\Response;
 use Joomla\Uri\Uri;
 use Joomla\Registry\Registry;
@@ -75,14 +76,14 @@ abstract class AbstractGithubObject
 	 * Constructor.
 	 *
 	 * @param   Registry  $options  GitHub options object.
-	 * @param   Http      $client   The HTTP client object.
+	 * @param   BaseHttp  $client   The HTTP client object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null)
+	public function __construct(Registry $options = null, BaseHttp $client = null)
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client = isset($client) ? $client : new Http($this->options);
+		$this->options = $options ?: new Registry;
+		$this->client = $client ?: new Http($this->options);
 
 		$this->package = get_class($this);
 		$this->package = substr($this->package, strrpos($this->package, '\\') + 1);

--- a/src/AbstractPackage.php
+++ b/src/AbstractPackage.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Github;
 
+use Joomla\Http\Http as BaseHttp;
 use Joomla\Registry\Registry;
 
 /**
@@ -21,11 +22,11 @@ abstract class AbstractPackage extends AbstractGithubObject
 	 * Constructor.
 	 *
 	 * @param   Registry  $options  GitHub options object.
-	 * @param   Http      $client   The HTTP client object.
+	 * @param   BaseHttp  $client   The HTTP client object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null)
+	public function __construct(Registry $options = null, BaseHttp $client = null)
 	{
 		parent::__construct($options, $client);
 

--- a/src/Github.php
+++ b/src/Github.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Github;
 
+use Joomla\Http\Http as BaseHttp;
 use Joomla\Registry\Registry;
 
 /**
@@ -50,14 +51,14 @@ class Github
 	 * Constructor.
 	 *
 	 * @param   Registry  $options  GitHub options object.
-	 * @param   Http      $client   The HTTP client object.
+	 * @param   BaseHttp  $client   The HTTP client object.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Registry $options = null, Http $client = null)
+	public function __construct(Registry $options = null, BaseHttp $client = null)
 	{
-		$this->options = isset($options) ? $options : new Registry;
-		$this->client  = isset($client) ? $client : new Http($this->options);
+		$this->options = $options ?: new Registry;
+		$this->client  = $client ?: new Http($this->options);
 
 		// Setup the default API url if not already set.
 		if (!$this->getOption('api.url'))

--- a/src/Github.php
+++ b/src/Github.php
@@ -58,13 +58,20 @@ class Github
 	public function __construct(Registry $options = null, BaseHttp $client = null)
 	{
 		$this->options = $options ?: new Registry;
-		$this->client  = $client ?: new Http($this->options);
+
+		// Setup the default user agent if not already set.
+		if (!$this->getOption('userAgent'))
+		{
+			$this->setOption('userAgent', 'JGitHub/2.0');
+		}
 
 		// Setup the default API url if not already set.
 		if (!$this->getOption('api.url'))
 		{
 			$this->setOption('api.url', 'https://api.github.com');
 		}
+
+		$this->client = $client ?: new Http($this->options);
 	}
 
 	/**

--- a/src/Http.php
+++ b/src/Http.php
@@ -14,25 +14,29 @@ use Joomla\Http\TransportInterface;
 /**
  * HTTP client class for connecting to a GitHub instance.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use Joomla\Http\Http instead
  */
 class Http extends BaseHttp
 {
 	/**
 	 * @const  integer  Use no authentication for HTTP connections.
 	 * @since  1.0
+	 * @deprecated  2.0
 	 */
 	const AUTHENTICATION_NONE = 0;
 
 	/**
 	 * @const  integer  Use basic authentication for HTTP connections.
 	 * @since  1.0
+	 * @deprecated  2.0
 	 */
 	const AUTHENTICATION_BASIC = 1;
 
 	/**
 	 * @const  integer  Use OAuth authentication for HTTP connections.
 	 * @since  1.0
+	 * @deprecated  2.0
 	 */
 	const AUTHENTICATION_OAUTH = 2;
 
@@ -43,6 +47,7 @@ class Http extends BaseHttp
 	 * @param   TransportInterface  $transport  The HTTP transport object.
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0
 	 */
 	public function __construct($options = array(), TransportInterface $transport = null)
 	{


### PR DESCRIPTION
The `Joomla\Github\Http` subclass adds no real value to the API other than defining an arbitrary default user agent and a request timeout, as well as defining some class constants for features that were never developed.  Let's deprecate this and allow the base `Joomla\Http\Http` class to be injected instead.