### PR TITLE
Add updateBranch feature from v3 api preview

### DIFF
--- a/src/Package/Pulls.php
+++ b/src/Package/Pulls.php
@@ -311,4 +311,32 @@ class Pulls extends AbstractPackage
 		// Send the request.
 		return $this->processResponse($this->client->put($this->fetchUrl($path), $data));
 	}
+
+	/**
+	 * Update a pull request branch
+	 *
+	 * @param   string   $user    The name of the owner of the GitHub repository.
+	 * @param   string   $repo    The name of the GitHub repository.
+ 	 * @param   integer  $pullId  The pull request number.
+	 *
+	 * @return  object
+	 *
+	 * @since   1.0
+	 * @throws  \DomainException
+	 */
+	public function updateBranch($user, $repo, $pullId)
+	{
+		// Build the request path.
+		$path = '/repos/' . $user . '/' . $repo . '/pulls/' . $pullId . '/update-branch';
+
+		/**
+		 * Note: Updating the pull request branch with latest upstream changes is currently available
+		 * for developers to preview. To access this new endpoint during the preview period, you must
+		 * provide a custom media type in the Accept header: application/vnd.github.lydian-preview+json
+		 */
+		$headers = array('Accept' => 'application/vnd.github.lydian-preview+json');
+		
+		// Send the request.
+		return $this->processResponse($this->client->put($this->fetchUrl($path), $headers), 202);
+	}
 }

--- a/src/Package/Pulls.php
+++ b/src/Package/Pulls.php
@@ -317,7 +317,7 @@ class Pulls extends AbstractPackage
 	 *
 	 * @param   string   $user    The name of the owner of the GitHub repository.
 	 * @param   string   $repo    The name of the GitHub repository.
- 	 * @param   integer  $pullId  The pull request number.
+	 * @param   integer  $pullId  The pull request number.
 	 *
 	 * @return  object
 	 *
@@ -335,7 +335,7 @@ class Pulls extends AbstractPackage
 		 * provide a custom media type in the Accept header: application/vnd.github.lydian-preview+json
 		 */
 		$headers = array('Accept' => 'application/vnd.github.lydian-preview+json');
-		
+
 		// Send the request.
 		return $this->processResponse($this->client->put($this->fetchUrl($path), $headers), 202);
 	}


### PR DESCRIPTION
### Summary of Changes

Add updateBranch feature from v3 api preview: More Infos: https://developer.github.com/v3/pulls/#update-a-pull-request-branch

### Testing Instructions

`$pull = $github->pulls->updateBranch(':owner', ':repo', ':pullId');`

### Documentation Changes Required

Should I add the example to the readme too?