### PR TITLE
Add the auth token to the header and unset the gh.token value

### DIFF
--- a/src/Github.php
+++ b/src/Github.php
@@ -75,6 +75,20 @@ class Github
 			$this->setOption('api.url', 'https://api.github.com');
 		}
 
+		// Add the auth token to the header and unset the gh.token value
+		if ($this->getOption('gh.token'))
+		{
+			$headers = $this->getOption('headers', []);
+
+			if (!isset($headers['Authorization']))
+			{
+				$headers['Authorization'] = 'token ' . $this->getOption('gh.token');
+				$this->setOption('gh.token', '');
+			}
+
+			$this->setOption('headers', $headers);
+		}
+		
 		$this->client = $client ?: new Http($this->options);
 	}
 


### PR DESCRIPTION
Pull Request for Issue about deprecated password auth details: https://developer.github.com/changes/2020-02-14-deprecating-password-auth/; Redo of: https://github.com/joomla-framework/github-api/pull/45

Well yes i know this is not oauth but that should work right? 

### Summary of Changes

Pass the token to the http class as header.

### Testing Instructions

- Make sure the http header is set in the request.
- Make sure the auth using the token still works

### Questions

- We might should remove the other code for that auth token stuff?
- Or should this be better done in the implementation application and we wait here until we get the oauth stuff running?

> Also I would rename gh.token to api.token

I'm not sure whether we should intentional break B/C with that change.

cc @HLeithner @Hackwar