### PR TITLE
Refactoring

### DIFF
--- a/Tests/GithubObjectTest.php
+++ b/Tests/GithubObjectTest.php
@@ -147,10 +147,18 @@ class GithubObjectTest extends GitHubTestCase
 
 		$this->object = new ObjectMock($this->options, $this->client);
 
+		$clientBeforeFetchUrl = clone $this->client;
+
 		self::assertEquals(
 			'https://api.github.com/gists',
 			(string) $this->object->fetchUrl('/gists', 0, 0),
 			'URL is not as expected.'
+		);
+
+		self::assertEquals(
+			$clientBeforeFetchUrl,
+			$this->client,
+			'HTTP client should not have changed'
 		);
 
 		self::assertEquals(

--- a/Tests/GithubObjectTest.php
+++ b/Tests/GithubObjectTest.php
@@ -143,8 +143,9 @@ class GithubObjectTest extends GitHubTestCase
 	public function testFetchUrlToken()
 	{
 		$this->options->set('api.url', 'https://api.github.com');
-
 		$this->options->set('gh.token', 'MyTestToken');
+
+		$this->object = new ObjectMock($this->options, $this->client);
 
 		self::assertEquals(
 			'https://api.github.com/gists',

--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -103,6 +103,11 @@ abstract class AbstractGithubObject
 			$this->options['timeout'] = 120;
 		}
 
+		if ($this->options->get('gh.token', false))
+		{
+			$this->client->setOption('headers', array('Authorization' => 'token ' . $this->options->get('gh.token')));
+		}
+
 		$this->package = \get_class($this);
 		$this->package = substr($this->package, strrpos($this->package, '\\') + 1);
 	}
@@ -126,18 +131,7 @@ abstract class AbstractGithubObject
 		// Get a new Uri object focusing the api url and given path.
 		$uri = new Uri($this->options->get('api.url') . $path);
 
-		if ($this->options->get('gh.token', false))
-		{
-			// Use oAuth authentication
-			$headers = $this->client->getOption('headers', array());
-
-			if (!isset($headers['Authorization']))
-			{
-				$headers['Authorization'] = 'token ' . $this->options->get('gh.token');
-				$this->client->setOption('headers', $headers);
-			}
-		}
-		else
+		if (!$this->options->get('gh.token', false))
 		{
 			// Use basic authentication
 			if ($this->options->get('api.username', false))


### PR DESCRIPTION
### Summary of Changes

Before this change, `AbstractGithubObject::fetchUrl()` altered the HTTP client on the fly to add header data. Since the header data is not part of the URL, this undocumented side effect is just wrong.
Now, the options are propagated to the client in the constructor, where it should be.

### Testing Instructions

See `GithubObjectTest::testFetchUrlToken()`.

### Documentation Changes Required

No.