### PR TITLE
Adding missing use statement

### DIFF
--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -10,6 +10,7 @@ namespace Joomla\Github;
 
 use Joomla\Http\Exception\UnexpectedResponseException;
 use Joomla\Http\Http as BaseHttp;
+use Joomla\Http\HttpFactory;
 use Joomla\Http\Response;
 use Joomla\Registry\Registry;
 use Joomla\Uri\Uri;


### PR DESCRIPTION
On line 92 we are using the HttpFactory, which hasn't been added to the use block at the beginning of the file. This results in an error in the unit tests of the joomla statistics server.
