### PR TITLE
[4.0] Change access to body of Response object

### DIFF
--- a/Tests/Package/Activity/EventsTest.php
+++ b/Tests/Package/Activity/EventsTest.php
@@ -62,8 +62,7 @@ class EventsTest extends GitHubTestCase
             ->with('/events')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -85,8 +84,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -109,7 +107,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -132,7 +129,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -155,7 +151,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -178,7 +173,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -201,7 +195,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -224,7 +217,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -247,7 +239,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -270,7 +261,6 @@ class EventsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/EventsTest.php
+++ b/Tests/Package/Activity/EventsTest.php
@@ -5,7 +5,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Github\Tests;
+namespace Joomla\Github\Tests\Package\Activity;
 
 use Joomla\Github\Package\Activity\Events;
 use Joomla\Github\Tests\Stub\GitHubTestCase;
@@ -106,7 +106,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -128,7 +128,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -150,7 +150,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -172,7 +172,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -194,7 +194,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -216,7 +216,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -238,7 +238,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -260,7 +260,7 @@ class EventsTest extends GitHubTestCase
             ->with($path)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/FeedsTest.php
+++ b/Tests/Package/Activity/FeedsTest.php
@@ -50,8 +50,7 @@ class FeedsTest extends GitHubTestCase
             ->with('/feeds')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/NotificationsTest.php
+++ b/Tests/Package/Activity/NotificationsTest.php
@@ -54,8 +54,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications?all=1&participating=1&since=2005-08-17T00:00:00+00:00&before=2005-08-17T00:00:00+00:00', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -79,8 +78,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/repos/{owner}/{repo}/notifications?' . $args, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -111,8 +109,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications', '{"unread":true,"read":true}', [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -139,8 +136,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -166,8 +162,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/notifications', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -195,7 +190,6 @@ class NotificationsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -218,7 +212,6 @@ class NotificationsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -243,7 +236,6 @@ class NotificationsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -266,7 +258,6 @@ class NotificationsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -289,7 +280,6 @@ class NotificationsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -314,7 +304,6 @@ class NotificationsTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/NotificationsTest.php
+++ b/Tests/Package/Activity/NotificationsTest.php
@@ -5,7 +5,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Github\Tests;
+namespace Joomla\Github\Tests\Package\Activity;
 
 use Joomla\Github\Package\Activity\Notifications;
 use Joomla\Github\Tests\Stub\GitHubTestCase;
@@ -189,7 +189,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/notifications', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -211,7 +211,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications/threads/1', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -235,7 +235,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications/threads/1', '{"unread":true,"read":true}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -257,7 +257,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications/threads/1/subscription', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -279,7 +279,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications/threads/1/subscription', '{"subscribed":true,"ignored":false}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -303,7 +303,7 @@ class NotificationsTest extends GitHubTestCase
             ->with('/notifications/threads/1/subscription', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/StarringTest.php
+++ b/Tests/Package/Activity/StarringTest.php
@@ -54,8 +54,7 @@ class StarringTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/stargazers', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -77,8 +76,7 @@ class StarringTest extends GitHubTestCase
             ->with('/user/starred?sort=created&direction=desc', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -100,8 +98,7 @@ class StarringTest extends GitHubTestCase
             ->with('/users/{user}/starred?sort=created&direction=desc', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -157,8 +154,7 @@ class StarringTest extends GitHubTestCase
             ->with('/user/starred/joomla/joomla-platform', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -183,7 +179,6 @@ class StarringTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -210,7 +205,6 @@ class StarringTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -235,7 +229,6 @@ class StarringTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -260,7 +253,6 @@ class StarringTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/StarringTest.php
+++ b/Tests/Package/Activity/StarringTest.php
@@ -5,7 +5,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Github\Tests;
+namespace Joomla\Github\Tests\Package\Activity;
 
 use Joomla\Github\Package\Activity\Starring;
 use Joomla\Github\Tests\Stub\GitHubTestCase;
@@ -178,7 +178,7 @@ class StarringTest extends GitHubTestCase
             ->with('/user/starred/joomla/joomla-platform', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -204,7 +204,7 @@ class StarringTest extends GitHubTestCase
             ->with('/user/starred/joomla/joomla-platform', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -228,7 +228,7 @@ class StarringTest extends GitHubTestCase
             ->with('/user/starred/joomla/joomla-platform', '', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -252,7 +252,7 @@ class StarringTest extends GitHubTestCase
             ->with('/user/starred/joomla/joomla-platform', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Activity/WatchingTest.php
+++ b/Tests/Package/Activity/WatchingTest.php
@@ -50,8 +50,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/subscribers', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -71,8 +70,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/user/subscriptions', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -92,8 +90,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/users/joomla/subscriptions', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -113,8 +110,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/subscription', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -134,8 +130,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/subscription', '{"subscribed":true,"ignored":false}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -157,8 +152,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/subscription', [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -239,8 +233,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/user/subscriptions/joomla/joomla-platform', '', [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -262,8 +255,7 @@ class WatchingTest extends GitHubTestCase
             ->with('/user/subscriptions/joomla/joomla-platform', [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/AuthorizationsTest.php
+++ b/Tests/Package/AuthorizationsTest.php
@@ -575,8 +575,7 @@ class AuthorizationsTest extends GitHubTestCase
         $this->response = $this->getResponseObject('https://github.com/login/oauth/authorize?client_id=12345'
             . '&redirect_uri=aaa&scope=bbb&state=ccc', 200);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -598,8 +597,7 @@ class AuthorizationsTest extends GitHubTestCase
             ->with('https://github.com/login/oauth/access_token')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -621,8 +619,7 @@ class AuthorizationsTest extends GitHubTestCase
             ->with('https://github.com/login/oauth/access_token')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -644,8 +641,7 @@ class AuthorizationsTest extends GitHubTestCase
             ->with('https://github.com/login/oauth/access_token')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Data/BlobsTest.php
+++ b/Tests/Package/Data/BlobsTest.php
@@ -50,8 +50,7 @@ class BlobsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/blobs/12345', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -73,8 +72,7 @@ class BlobsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/blobs', '{"content":"Hello w\u00f6rld","encoding":"utf-8"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Data/CommitsTest.php
+++ b/Tests/Package/Data/CommitsTest.php
@@ -50,8 +50,7 @@ class CommitsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/commits/12345', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -73,8 +72,7 @@ class CommitsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/commits', '{"message":"My Message","tree":"12345","parents":[]}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Data/TagsTest.php
+++ b/Tests/Package/Data/TagsTest.php
@@ -50,8 +50,7 @@ class TagsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/tags/12345', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -75,8 +74,7 @@ class TagsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/tags', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Data/TreesTest.php
+++ b/Tests/Package/Data/TreesTest.php
@@ -50,8 +50,7 @@ class TreesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/trees/12345', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -71,8 +70,7 @@ class TreesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/trees/12345?recursive=1', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -94,8 +92,7 @@ class TreesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/git/trees', '{"tree":"12345","base_tree":"678"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/GitignoreTest.php
+++ b/Tests/Package/GitignoreTest.php
@@ -62,8 +62,7 @@ class GitignoreTest extends GitHubTestCase
             ->with('/gitignore/templates', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -92,8 +91,7 @@ class GitignoreTest extends GitHubTestCase
             ->with('/gitignore/templates/C', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -135,8 +133,7 @@ class GitignoreTest extends GitHubTestCase
             ->with('/gitignore/templates/C', ['Accept' => 'application/vnd.github.raw+json'], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -161,8 +158,7 @@ class GitignoreTest extends GitHubTestCase
             ->with('/gitignore/templates/X', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Issues/AssigneesTest.php
+++ b/Tests/Package/Issues/AssigneesTest.php
@@ -73,8 +73,7 @@ class AssigneesTest extends GitHubTestCase
             ->with('/repos/' . $this->owner . '/' . $this->repo . '/assignees', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -185,8 +184,7 @@ class AssigneesTest extends GitHubTestCase
             ->with('/repos/' . $this->owner . '/' . $this->repo . '/issues/123/assignees', json_encode(['assignees' => ['joomla']]))
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -217,8 +215,7 @@ class AssigneesTest extends GitHubTestCase
             ->with('/repos/' . $this->owner . '/' . $this->repo . '/issues/123/assignees', [], null, json_encode(['assignees' => ['joomla']]))
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Issues/CommentsTest.php
+++ b/Tests/Package/Issues/CommentsTest.php
@@ -50,8 +50,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/comments', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -71,8 +70,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/comments?sort=created&direction=asc', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -118,8 +116,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/comments?sort=created&direction=asc&since=1966-09-15T12:34:56+00:00', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -139,8 +136,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/comments/1', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -160,8 +156,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/comments/1', '{"body":"Hello"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -183,8 +178,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/comments', '{"body":"Hello"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Issues/EventsTest.php
+++ b/Tests/Package/Issues/EventsTest.php
@@ -50,8 +50,7 @@ class EventsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/events', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -71,8 +70,7 @@ class EventsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/comments', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -92,8 +90,7 @@ class EventsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/events/1', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Issues/LabelsTest.php
+++ b/Tests/Package/Issues/LabelsTest.php
@@ -50,8 +50,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/labels', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -71,8 +70,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/labels/1', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -94,8 +92,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/labels', '{"name":"foobar","color":"red"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -119,8 +116,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/labels', '{"name":"foobar","color":"red"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -140,8 +136,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/labels/foobar', '{"name":"boofaz","color":"red"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -163,8 +158,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/labels/foobar', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -184,8 +178,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/labels', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -205,8 +198,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/labels', '["A","B"]', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -226,8 +218,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/labels/foobar', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -247,8 +238,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/labels', '["A","B"]', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -270,8 +260,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/issues/1/labels', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -291,8 +280,7 @@ class LabelsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/milestones/1/labels', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Issues/MilestonesTest.php
+++ b/Tests/Package/Issues/MilestonesTest.php
@@ -58,8 +58,7 @@ class MilestonesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/milestones', $milestone)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -109,8 +108,7 @@ class MilestonesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/milestones/523', json_encode($milestone))
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/MarkdownTest.php
+++ b/Tests/Package/MarkdownTest.php
@@ -71,8 +71,7 @@ class MarkdownTest extends GitHubTestCase
             ->with('/markdown', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Pulls/CommentsTest.php
+++ b/Tests/Package/Pulls/CommentsTest.php
@@ -56,8 +56,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/pulls/1/comments', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -81,8 +80,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/pulls/1/comments', '{"body":"The Body","in_reply_to":456}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -106,8 +104,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/pulls/comments/456', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -131,8 +128,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/pulls/comments/456', '{"body":"Hello"}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -154,8 +150,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/pulls/comments/456', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -177,8 +172,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/pulls/456/comments', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -200,8 +194,7 @@ class CommentsTest extends GitHubTestCase
             ->with('/repos/{user}/{repo}/pulls/comments', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Repositories/CollaboratorsTest.php
+++ b/Tests/Package/Repositories/CollaboratorsTest.php
@@ -69,8 +69,7 @@ class CollaboratorsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-framework/collaborators/elkuku')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -92,8 +91,7 @@ class CollaboratorsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-framework/collaborators/elkuku')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -117,8 +115,7 @@ class CollaboratorsTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-framework/collaborators/elkuku')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Repositories/ForksTest.php
+++ b/Tests/Package/Repositories/ForksTest.php
@@ -101,8 +101,7 @@ class ForksTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/forks')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Repositories/ReleasesTest.php
+++ b/Tests/Package/Repositories/ReleasesTest.php
@@ -4,7 +4,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Github\Tests;
+namespace Joomla\Github\Tests\Package\Repositories;
 
 use Joomla\Github\Package\Repositories\Releases;
 use Joomla\Github\Tests\Stub\GitHubTestCase;
@@ -96,7 +96,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -120,7 +120,7 @@ class ReleasesTest extends GitHubTestCase
 
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -139,7 +139,7 @@ class ReleasesTest extends GitHubTestCase
 
         $releases = [];
 
-        foreach (json_decode($this->response->getBody()->getContents()) as $i => $release) {
+        foreach (json_decode((string) $this->response->getBody()) as $i => $release) {
             $releases[$i + 1] = $release;
         }
 
@@ -148,7 +148,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $releases,
@@ -170,7 +170,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/123')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -194,7 +194,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/latest', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -214,7 +214,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/tags/{tag}', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -234,7 +234,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/123/assets', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -254,7 +254,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/assets/123', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -276,7 +276,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/assets/123', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Repositories/ReleasesTest.php
+++ b/Tests/Package/Repositories/ReleasesTest.php
@@ -50,8 +50,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases/12345', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -74,8 +73,7 @@ class ReleasesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-platform/releases', $data, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -99,7 +97,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -124,7 +121,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -153,7 +149,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $releases,
@@ -176,7 +171,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -201,7 +195,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -222,7 +215,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -243,7 +235,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -264,7 +255,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -287,7 +277,6 @@ class ReleasesTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/RepositoriesTest.php
+++ b/Tests/Package/RepositoriesTest.php
@@ -48,8 +48,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/user/repos?type=all&sort=full_name&direction=asc', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -105,8 +104,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/users/joomla/repos?type=all&sort=full_name&direction=asc', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -162,8 +160,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/orgs/joomla/repos?type=all', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -183,8 +180,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repositories', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -212,8 +208,7 @@ class RepositoriesTest extends GitHubTestCase
             )
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -241,8 +236,7 @@ class RepositoriesTest extends GitHubTestCase
             )
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -262,8 +256,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-cms', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -300,8 +293,7 @@ class RepositoriesTest extends GitHubTestCase
             )
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -321,8 +313,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-cms/contributors', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -342,8 +333,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-cms/languages', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -363,8 +353,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-cms/teams', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -384,8 +373,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-cms/tags', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -405,8 +393,7 @@ class RepositoriesTest extends GitHubTestCase
             ->with('/repos/joomla/joomla-cms', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/Users/FollowersTest.php
+++ b/Tests/Package/Users/FollowersTest.php
@@ -136,8 +136,7 @@ class FollowersTest extends GitHubTestCase
             ->with('/user/following/joomla')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -163,8 +162,7 @@ class FollowersTest extends GitHubTestCase
             ->with('/user/following/joomla')
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -190,8 +188,7 @@ class FollowersTest extends GitHubTestCase
             ->with('/user/following/joomla')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -215,8 +212,7 @@ class FollowersTest extends GitHubTestCase
             ->with('/user/following/joomla')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -240,8 +236,7 @@ class FollowersTest extends GitHubTestCase
             ->with('/user/following/joomla')
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/UsersTest.php
+++ b/Tests/Package/UsersTest.php
@@ -4,7 +4,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Github\Tests;
+namespace Joomla\Github\Tests\Package;
 
 use Joomla\Github\Package\Users;
 use Joomla\Github\Tests\Stub\GitHubTestCase;
@@ -176,7 +176,7 @@ class UsersTest extends GitHubTestCase
             ->with('/user', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -216,7 +216,7 @@ class UsersTest extends GitHubTestCase
             ->with('/users', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -289,7 +289,7 @@ class UsersTest extends GitHubTestCase
             ->with('/user', $input, [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -336,7 +336,7 @@ class UsersTest extends GitHubTestCase
         // $this->object->edit($name, $email, $blog, $company, $location, $hireable, $bio);
 
         $this->assertEquals(
-            json_decode($this->response->getBody()->getContents()),
+            json_decode((string) $this->response->getBody()),
             $this->object->edit($name, $email, $blog, $company, $location, $hireable, $bio)
         );
     }

--- a/Tests/Package/UsersTest.php
+++ b/Tests/Package/UsersTest.php
@@ -72,8 +72,7 @@ class UsersTest extends GitHubTestCase
             ->with('/users/joomla', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -97,8 +96,7 @@ class UsersTest extends GitHubTestCase
             ->with('/users/nonexistentuser', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -152,8 +150,7 @@ class UsersTest extends GitHubTestCase
             ->with('/user', [], 0)
             ->willReturn($this->response);
 
-        $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
+        $response = json_decode((string) $this->response->getBody());
 
         $this->assertEquals(
             $response,
@@ -180,7 +177,6 @@ class UsersTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -221,7 +217,6 @@ class UsersTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,
@@ -295,7 +290,6 @@ class UsersTest extends GitHubTestCase
             ->willReturn($this->response);
 
         $response = json_decode($this->response->getBody()->getContents());
-        $this->response->getBody()->rewind();
 
         $this->assertEquals(
             $response,

--- a/Tests/Package/ZenTest.php
+++ b/Tests/Package/ZenTest.php
@@ -51,8 +51,7 @@ class ZenTest extends GitHubTestCase
             ->with('/zen', [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,
@@ -76,8 +75,7 @@ class ZenTest extends GitHubTestCase
             ->with('/zen', [], 0)
             ->willReturn($this->response);
 
-        $response = $this->response->getBody()->getContents();
-        $this->response->getBody()->rewind();
+        $response = (string) $this->response->getBody();
 
         $this->assertEquals(
             $response,

--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -163,12 +163,12 @@ abstract class AbstractGithubObject
         // Validate the response code.
         if ($response->getStatusCode() != $expectedCode) {
             // Decode the error response and throw an exception.
-            $error   = json_decode($response->getBody()->getContents());
+            $error   = json_decode((string) $response->getBody());
             $message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
 
             throw new UnexpectedResponseException($response, $message, $response->getStatusCode());
         }
 
-        return json_decode($response->getBody()->getContents());
+        return json_decode((string) $response->getBody());
     }
 }

--- a/src/Package/Authorization.php
+++ b/src/Package/Authorization.php
@@ -249,12 +249,12 @@ class Authorization extends AbstractPackage
             }
 
             // Decode the error response and throw an exception.
-            $error = json_decode($response->getBody()->getContents());
+            $error = json_decode((string) $response->getBody());
 
             throw new UnexpectedResponseException($response, $error->message, $response->getStatusCode());
         }
 
-        return json_decode($response->getBody()->getContents());
+        return json_decode((string) $response->getBody());
     }
 
     /**

--- a/src/Package/Gists.php
+++ b/src/Package/Gists.php
@@ -342,7 +342,7 @@ class Gists extends AbstractPackage
         }
 
         // Decode the error response and throw an exception.
-        $error   = json_decode($response->getBody()->getContents());
+        $error   = json_decode((string) $response->getBody());
         $message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
 
         throw new UnexpectedResponseException($response, $message, $response->getStatusCode());

--- a/src/Package/Gitignore.php
+++ b/src/Package/Gitignore.php
@@ -70,12 +70,12 @@ class Gitignore extends AbstractPackage
         // Validate the response code.
         if ($response->getStatusCode() != 200) {
             // Decode the error response and throw an exception.
-            $error   = json_decode($response->getBody()->getContents());
+            $error   = json_decode((string) $response->getBody());
             $message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
 
             throw new UnexpectedResponseException($response, $message, $response->getStatusCode());
         }
 
-        return ($raw) ? $response->getBody()->getContents() : json_decode($response->getBody()->getContents());
+        return ($raw) ? (string) $response->getBody() : json_decode((string) $response->getBody());
     }
 }

--- a/src/Package/Markdown.php
+++ b/src/Package/Markdown.php
@@ -66,12 +66,12 @@ class Markdown extends AbstractPackage
         // Validate the response code.
         if ($response->getStatusCode() != 200) {
             // Decode the error response and throw an exception.
-            $error   = json_decode($response->getBody()->getContents());
+            $error   = json_decode((string) $response->getBody());
             $message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
 
             throw new UnexpectedResponseException($response, $message, $response->getStatusCode());
         }
 
-        return $response->getBody()->getContents();
+        return (string) $response->getBody();
     }
 }

--- a/src/Package/Orgs/Members.php
+++ b/src/Package/Orgs/Members.php
@@ -50,7 +50,7 @@ class Members extends AbstractPackage
                 return false;
 
             case 200:
-                return json_decode($response->getBody()->getContents());
+                return json_decode((string) $response->getBody());
 
             default:
                 throw new \UnexpectedValueException('Unexpected response code: ' . $response->getStatusCode());

--- a/src/Package/Orgs/Teams.php
+++ b/src/Package/Orgs/Teams.php
@@ -297,7 +297,7 @@ class Teams extends AbstractPackage
         switch ($response->getStatusCode()) {
             case 200:
                 // Response if user is an active member or pending membership
-                $body = json_decode($response->getBody()->getContents());
+                $body = json_decode((string) $response->getBody());
 
                 return $body->state;
 

--- a/src/Package/Pulls.php
+++ b/src/Package/Pulls.php
@@ -271,7 +271,7 @@ class Pulls extends AbstractPackage
         }
 
         // Decode the error response and throw an exception.
-        $error   = json_decode($response->getBody()->getContents());
+        $error   = json_decode((string) $response->getBody());
         $message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
 
         throw new UnexpectedResponseException($response, $message, $response->getStatusCode());

--- a/src/Package/Repositories/Commits.php
+++ b/src/Package/Repositories/Commits.php
@@ -117,13 +117,13 @@ class Commits extends AbstractPackage
         // Validate the response code.
         if ($response->getStatusCode() != 200) {
             // Decode the error response and throw an exception.
-            $error   = json_decode($response->getBody()->getContents());
+            $error   = json_decode((string) $response->getBody());
             $message = isset($error->message) ? $error->message : 'Invalid response received from GitHub.';
 
             throw new UnexpectedResponseException($response, $message, $response->getStatusCode());
         }
 
-        return $response->getBody()->getContents();
+        return (string) $response->getBody();
     }
 
     /**

--- a/src/Package/Repositories/Deployments.php
+++ b/src/Package/Repositories/Deployments.php
@@ -129,11 +129,11 @@ class Deployments extends AbstractPackage
         switch ($response->getStatusCode()) {
             case 201:
                 // The deployment was successful
-                return json_decode($response->getBody()->getContents());
+                return json_decode((string) $response->getBody());
 
             case 409:
                 // There was a merge conflict or a status check failed.
-                $body    = json_decode($response->getBody()->getContents());
+                $body    = json_decode((string) $response->getBody());
                 $message = isset($body->message) ? $body->message : 'Invalid response received from GitHub.';
 
                 throw new \RuntimeException($message, $response->getStatusCode());

--- a/src/Package/Repositories/Merging.php
+++ b/src/Package/Repositories/Merging.php
@@ -55,7 +55,7 @@ class Merging extends AbstractPackage
         switch ($response->getStatusCode()) {
             case '201':
                 // Success
-                return json_decode($response->getBody()->getContents());
+                return json_decode((string) $response->getBody());
 
             case '204':
                 // No-op response (base already contains the head, nothing to merge)
@@ -63,7 +63,7 @@ class Merging extends AbstractPackage
 
             case '404':
                 // Missing base or Missing head response
-                $error = json_decode($response->getBody()->getContents());
+                $error = json_decode((string) $response->getBody());
 
                 $message = (isset($error->message)) ? $error->message : 'Missing base or head: ' . $response->getStatusCode();
 
@@ -71,7 +71,7 @@ class Merging extends AbstractPackage
 
             case '409':
                 // Merge conflict response
-                $error = json_decode($response->getBody()->getContents());
+                $error = json_decode((string) $response->getBody());
 
                 $message = (isset($error->message)) ? $error->message : 'Merge conflict ' . $response->getStatusCode();
 

--- a/src/Package/Zen.php
+++ b/src/Package/Zen.php
@@ -35,6 +35,6 @@ class Zen extends AbstractPackage
             throw new \RuntimeException('Can\'t get a Zen');
         }
 
-        return $response->getBody()->getContents();
+        return (string) $response->getBody();
     }
 }


### PR DESCRIPTION
### Summary of Changes
When converting the code to v4 of the Joomla HTTP package, the method `Response->getBody()->getContents()` was used to access the body of the response, which can be problematic, when the pointer of the internal stream is not set to the beginning. This PR changes the code to use the magic `__toString()` method of the `StreamInterface` instead.

### Testing Instructions
Codereview

### Documentation Changes Required
none