### PR TITLE
[3.x][PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/src/AbstractGithubObject.php
+++ b/src/AbstractGithubObject.php
@@ -88,7 +88,7 @@ abstract class AbstractGithubObject
      *
      * @since   1.0
      */
-    public function __construct(Registry $options = null, BaseHttp $client = null)
+    public function __construct(?Registry $options = null, ?BaseHttp $client = null)
     {
         $this->options = $options ?: new Registry();
         $this->client  = $client ?: (new HttpFactory())->getHttp($this->options);

--- a/src/AbstractPackage.php
+++ b/src/AbstractPackage.php
@@ -27,7 +27,7 @@ abstract class AbstractPackage extends AbstractGithubObject
      *
      * @since   1.0
      */
-    public function __construct(Registry $options = null, Http $client = null)
+    public function __construct(?Registry $options = null, ?Http $client = null)
     {
         parent::__construct($options, $client);
 

--- a/src/Github.php
+++ b/src/Github.php
@@ -61,7 +61,7 @@ class Github
      *
      * @since   1.0
      */
-    public function __construct(Registry $options = null, Http $client = null)
+    public function __construct(?Registry $options = null, ?Http $client = null)
     {
         $this->options = $options ?: new Registry();
 

--- a/src/Package/Activity/Notifications.php
+++ b/src/Package/Activity/Notifications.php
@@ -34,7 +34,7 @@ class Notifications extends AbstractPackage
      *
      * @since   1.0
      */
-    public function getList($all = true, $participating = true, \DateTimeInterface $since = null, \DateTimeInterface $before = null)
+    public function getList($all = true, $participating = true, ?\DateTimeInterface $since = null, ?\DateTimeInterface $before = null)
     {
         // Build the request path.
         $path = '/notifications';
@@ -81,8 +81,8 @@ class Notifications extends AbstractPackage
         $repo,
         $all = true,
         $participating = true,
-        \DateTimeInterface $since = null,
-        \DateTimeInterface $before = null
+        ?\DateTimeInterface $since = null,
+        ?\DateTimeInterface $before = null
     ) {
         // Build the request path.
         $path = '/repos/' . $owner . '/' . $repo . '/notifications';
@@ -116,13 +116,13 @@ class Notifications extends AbstractPackage
      * @param   boolean              $unread      Changes the unread status of the threads.
      * @param   boolean              $read        Inverse of “unread”.
      * @param   ?\DateTimeInterface  $lastReadAt  Describes the last point that notifications were checked.
-     *                                           Anything updated since this time will not be updated. Default: Now. Expected in ISO 8601 format.
+     *                                            Anything updated since this time will not be updated. Default: Now. Expected in ISO 8601 format.
      *
      * @return  object
      *
      * @since   1.0
      */
-    public function markRead($unread = true, $read = true, \DateTimeInterface $lastReadAt = null)
+    public function markRead($unread = true, $read = true, ?\DateTimeInterface $lastReadAt = null)
     {
         // Build the request path.
         $path = '/notifications';
@@ -152,13 +152,13 @@ class Notifications extends AbstractPackage
      * @param   boolean              $unread      Changes the unread status of the threads.
      * @param   boolean              $read        Inverse of “unread”.
      * @param   ?\DateTimeInterface  $lastReadAt  Describes the last point that notifications were checked.
-     *                                           Anything updated since this time will not be updated. Default: Now. Expected in ISO 8601 format.
+     *                                            Anything updated since this time will not be updated. Default: Now. Expected in ISO 8601 format.
      *
      * @return  object
      *
      * @since   1.0
      */
-    public function markReadRepository($owner, $repo, $unread, $read, \DateTimeInterface $lastReadAt = null)
+    public function markReadRepository($owner, $repo, $unread, $read, ?\DateTimeInterface $lastReadAt = null)
     {
         // Build the request path.
         $path = '/repos/' . $owner . '/' . $repo . '/notifications';

--- a/src/Package/Gists.php
+++ b/src/Package/Gists.php
@@ -231,7 +231,7 @@ class Gists extends AbstractPackage
      * @since   1.0
      * @throws  \DomainException
      */
-    public function getListByUser($user, $page = 0, $limit = 0, \DateTime $since = null)
+    public function getListByUser($user, $page = 0, $limit = 0, ?\DateTime $since = null)
     {
         // Build the request path.
         $uri = $this->fetchUrl('/users/' . $user . '/gists', $page, $limit);
@@ -256,7 +256,7 @@ class Gists extends AbstractPackage
      * @since   1.0
      * @throws  \DomainException
      */
-    public function getListPublic($page = 0, $limit = 0, \DateTime $since = null)
+    public function getListPublic($page = 0, $limit = 0, ?\DateTime $since = null)
     {
         // Build the request path.
         $uri = $this->fetchUrl('/gists/public', $page, $limit);
@@ -281,7 +281,7 @@ class Gists extends AbstractPackage
      * @since   1.0
      * @throws  \DomainException
      */
-    public function getListStarred($page = 0, $limit = 0, \DateTime $since = null)
+    public function getListStarred($page = 0, $limit = 0, ?\DateTime $since = null)
     {
         // Build the request path.
         $uri = $this->fetchUrl('/gists/starred', $page, $limit);

--- a/src/Package/Issues.php
+++ b/src/Package/Issues.php
@@ -190,7 +190,7 @@ class Issues extends AbstractPackage
         $labels = null,
         $sort = null,
         $direction = null,
-        \DateTimeInterface $since = null,
+        ?\DateTimeInterface $since = null,
         $page = 0,
         $limit = 0
     ) {
@@ -256,7 +256,7 @@ class Issues extends AbstractPackage
         $labels = null,
         $sort = null,
         $direction = null,
-        \DateTimeInterface $since = null,
+        ?\DateTimeInterface $since = null,
         $page = 0,
         $limit = 0
     ) {

--- a/src/Package/Issues/Comments.php
+++ b/src/Package/Issues/Comments.php
@@ -38,7 +38,7 @@ class Comments extends AbstractPackage
      * @since   1.0
      * @throws  \DomainException
      */
-    public function getList($owner, $repo, $issueId, $page = 0, $limit = 0, \DateTimeInterface $since = null)
+    public function getList($owner, $repo, $issueId, $page = 0, $limit = 0, ?\DateTimeInterface $since = null)
     {
         // Build the request path.
         $path = '/repos/' . $owner . '/' . $repo . '/issues/' . (int) $issueId . '/comments';
@@ -68,7 +68,7 @@ class Comments extends AbstractPackage
      * @throws  \UnexpectedValueException
      * @throws  \DomainException
      */
-    public function getRepositoryList($owner, $repo, $sort = 'created', $direction = 'asc', \DateTimeInterface $since = null)
+    public function getRepositoryList($owner, $repo, $sort = 'created', $direction = 'asc', ?\DateTimeInterface $since = null)
     {
         // Build the request path.
         $path = '/repos/' . $owner . '/' . $repo . '/issues/comments';

--- a/src/Package/Repositories/Commits.php
+++ b/src/Package/Repositories/Commits.php
@@ -42,7 +42,7 @@ class Commits extends AbstractPackage
      * @since   1.0
      * @throws  \DomainException
      */
-    public function getList($user, $repo, $sha = '', $path = '', $author = '', \DateTimeInterface $since = null, \DateTimeInterface $until = null)
+    public function getList($user, $repo, $sha = '', $path = '', $author = '', ?\DateTimeInterface $since = null, ?\DateTimeInterface $until = null)
     {
         // Build the request path.
         $rPath = '/repos/' . $user . '/' . $repo . '/commits';


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no